### PR TITLE
[WIP] Clarify config subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ Usage:
     cargo-spellcheck [(-v...|-q)] fix [--cfg=<cfg>] [--checkers=<checkers>] [[--recursive] -- <paths>... ]
     cargo-spellcheck [(-v...|-q)] config (--user|--stdout|--cfg=<cfg>) [-f|--force]
     cargo-spellcheck [(-v...|-q)] [--cfg=<cfg>] (--fix|--interactive) [--checkers=<checkers>] [[--recursive] -- <paths>... ]
-    cargo-spellcheck (-h|--help)
+    cargo-spellcheck --help
     cargo-spellcheck --version
 
 Options:
@@ -48,7 +48,7 @@ Options:
   -c --cfg=<cfg>          Use a non default configuration file.
                           Passing a directory will attempt to open `cargo_spellcheck.toml` in that directory.
   --user                  Write the configuration file to the default user configuration directory.
-  --stdout                Print the configuration file to stdout without writing it.
+  --stdout                Print the configuration file to stdout and exit.
   -v --verbose            Verbosity level.
   -q --quiet              Silences all printed messages. Overrules `-v`.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ Usage:
     cargo-spellcheck [(-v...|-q)] fix [--cfg=<cfg>] [--checkers=<checkers>] [[--recursive] -- <paths>... ]
     cargo-spellcheck [(-v...|-q)] config [--force] [--user] [--cfg=<cfg>]
     cargo-spellcheck [(-v...|-q)] [--cfg=<cfg>] [(--fix|--interactive)] [--checkers=<checkers>] [[--recursive] -- <paths>... ]
+    cargo-spellcheck (--help|-h)
     cargo-spellcheck --version
 
 Options:
@@ -56,6 +57,7 @@ Options:
 struct Args {
     arg_paths: Vec<PathBuf>,
     flag_fix: bool,
+    flag_help: bool,
     flag_interactive: bool,
     flag_recursive: bool,
     flag_verbose: usize,
@@ -122,6 +124,11 @@ fn main() -> anyhow::Result<()> {
 
     if args.flag_version {
         println!("cargo-spellcheck {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
+    if args.flag_help {
+        println!("{}", USAGE);
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,9 @@ Spellcheck all your doc comments
 Usage:
     cargo-spellcheck [(-v...|-q)] check [--cfg=<cfg>] [--checkers=<checkers>] [[--recursive] -- <paths>... ]
     cargo-spellcheck [(-v...|-q)] fix [--cfg=<cfg>] [--checkers=<checkers>] [[--recursive] -- <paths>... ]
-    cargo-spellcheck [(-v...|-q)] config (--user|--stdout|--cfg=<cfg>) [--force]
+    cargo-spellcheck [(-v...|-q)] config (--user|--stdout|--cfg=<cfg>) [-f|--force]
     cargo-spellcheck [(-v...|-q)] [--cfg=<cfg>] (--fix|--interactive) [--checkers=<checkers>] [[--recursive] -- <paths>... ]
-    cargo-spellcheck (--help|-h)
+    cargo-spellcheck (-h|--help)
     cargo-spellcheck --version
 
 Options:
@@ -44,10 +44,10 @@ Options:
   -r --recursive          If a path is provided, if recursion into subdirectories is desired.
   --checkers=<checkers>   Calculate the intersection between
                           configured by config file and the ones provided on commandline.
-  --force                 Overwrite any existing configuration file. [default=false]
+  -f --force              Overwrite any existing configuration file. [default=false]
   -c --cfg=<cfg>          Use a non default configuration file.
                           Passing a directory will attempt to open `cargo_spellcheck.toml` in that directory.
-  --user                  Write the configuration file in the default user configuration directory. [default=false]
+  --user                  Write the configuration file to the default user configuration directory.
   --stdout                Print the configuration file to stdout without writing it.
   -v --verbose            Verbosity level.
   -q --quiet              Silences all printed messages. Overrules `-v`.

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -17,7 +17,6 @@ fn cwd() -> Result<PathBuf> {
     std::env::current_dir().map_err(|_e| anyhow::anyhow!("Missing cwd!"))
 }
 
-
 #[cfg(test)]
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
The `config` subcommand now either prints the default config with `--stdout`, writes the default config to the default user config with `--user` or to a custom path with `--cfg=<cfg>`.

Issues:
- since last subcommand had no required options, calling `cargo spellcheck config` was mistaken to be a call to this subcommand with `config` being interpreted as option `<paths>...`. I quickly fixed this by making `(--fix|--interactive)` required, but that's certainly not as required right? Whats the purpose of this last subcommand?
- should `cargo spellcheck --stdout` print the currently saved config instead of the default one?
- help message states that if `--cfg` is a directory, it attempts to open `cargo_spellchecl.toml` in that directory but that's not the case for `config`

Additionally: added handling of `--help` flag.