### PR TITLE
Interactive: don't advance to next suggestion on help message

### DIFF
--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -25,6 +25,10 @@ j - leave this hunk undecided, see next undecided hunk
 J - leave this hunk undecided, see next hunk
 e - manually edit the current hunk
 ? - print help
+
+
+
+
 "##;
 
 /// Helper strict to assure we leave the terminals raw mode
@@ -56,7 +60,6 @@ pub(super) enum Pick {
     Replacement(BandAid),
     Skip,
     Previous,
-    Help,
     SkipFile,
     Quit,
 }
@@ -269,7 +272,11 @@ impl UserPicked {
                 KeyCode::Char('q') | KeyCode::Esc => return Ok(Pick::Quit),
                 KeyCode::Char('d') => return Ok(Pick::SkipFile),
                 KeyCode::Char('e') => unimplemented!("Manual editing is a TODO"),
-                KeyCode::Char('?') => return Ok(Pick::Help),
+                KeyCode::Char('?') => {
+                    println!("{}", HELP);
+                    return self.user_input(suggestion, running_idx);
+                    //return Ok(Pick::Help),
+                }
                 x => {
                     trace!("Unexpected input {:?}", x);
                 }
@@ -330,10 +337,6 @@ impl UserPicked {
                     Pick::Skip => {}
                     Pick::Previous => {
                         unimplemented!("Requires a iterator which works bidrectionally")
-                    }
-                    Pick::Help => {
-                        println!("{}", HELP);
-                        break;
                     }
                     Pick::Replacement(bandaid) => {
                         picked.add_bandaid(&path, bandaid);

--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -340,7 +340,7 @@ impl UserPicked {
                     Pick::Previous => {
                         unimplemented!("Requires a iterator which works bidrectionally")
                     }
-                    Pick::Help => {}
+                    Pick::Help => unreachable!(),
                     Pick::Replacement(bandaid) => {
                         picked.add_bandaid(&path, bandaid);
                     }

--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -275,7 +275,6 @@ impl UserPicked {
                 KeyCode::Char('?') => {
                     println!("{}", HELP);
                     return self.user_input(suggestion, running_idx);
-                    //return Ok(Pick::Help),
                 }
                 x => {
                     trace!("Unexpected input {:?}", x);

--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -60,6 +60,7 @@ pub(super) enum Pick {
     Replacement(BandAid),
     Skip,
     Previous,
+    Help,
     SkipFile,
     Quit,
 }
@@ -272,10 +273,7 @@ impl UserPicked {
                 KeyCode::Char('q') | KeyCode::Esc => return Ok(Pick::Quit),
                 KeyCode::Char('d') => return Ok(Pick::SkipFile),
                 KeyCode::Char('e') => unimplemented!("Manual editing is a TODO"),
-                KeyCode::Char('?') => {
-                    println!("{}", HELP);
-                    return self.user_input(suggestion, running_idx);
-                }
+                KeyCode::Char('?') => return Ok(Pick::Help),
                 x => {
                     trace!("Unexpected input {:?}", x);
                 }
@@ -328,7 +326,12 @@ impl UserPicked {
                 }
                 println!("{}", suggestion);
 
-                match picked.user_input(&suggestion, (idx, count))? {
+                let mut pick = picked.user_input(&suggestion, (idx, count))?;
+                while pick == Pick::Help {
+                    println!("{}", HELP);
+                    pick = picked.user_input(&suggestion, (idx, count))?;
+                }
+                match pick {
                     Pick::Quit => {
                         unimplemented!("Quit properly and cleanly");
                     }
@@ -337,6 +340,7 @@ impl UserPicked {
                     Pick::Previous => {
                         unimplemented!("Requires a iterator which works bidrectionally")
                     }
+                    Pick::Help => {}
                     Pick::Replacement(bandaid) => {
                         picked.add_bandaid(&path, bandaid);
                     }


### PR DESCRIPTION
If `?` is pressed in interactive mode, stay on the current suggestion by recursively calling `user_input()` after printing `HELP`.
Adding the newlines to the `HELP` string is a workaround to avoid loosing some entries due to cursor moves in the selection code.