### PR TITLE
feature/interactive_replacement

### DIFF
--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -13,7 +13,7 @@ use crossterm::{
     terminal, QueueableCommand,
 };
 
-use std::io::stdout;
+use std::io::{stdout, stdin};
 use std::path::Path;
 
 const HELP: &'static str = r##"y - apply this suggestion
@@ -272,7 +272,45 @@ impl UserPicked {
                 KeyCode::Char('j') => return Ok(Pick::Previous),
                 KeyCode::Char('q') | KeyCode::Esc => return Ok(Pick::Quit),
                 KeyCode::Char('d') => return Ok(Pick::SkipFile),
-                KeyCode::Char('e') => unimplemented!("Manual editing is a TODO"),
+                KeyCode::Char('e') => {
+                    let guard = ScopedRaw::new();
+                    stdout()
+                        .queue(cursor::MoveToNextLine(0))    
+                        .unwrap()
+                        .queue(terminal::Clear(terminal::ClearType::CurrentLine))
+                        .unwrap()
+                        .queue(Print("replacement: "))
+                        .unwrap();
+                    let _ = stdout().flush();
+                    drop(guard);
+
+                    let mut replacement = String::new();
+                    loop {
+                        let event = match crossterm::event::read()
+                            .map_err(|e| anyhow::anyhow!("Something unexpected happened on the CLI: {}", e))?
+                        {
+                            Event::Key(event) => event,
+                            sth => {
+                                trace!("read() something other than a key: {:?}", sth);
+                                break;
+                            }
+                        };
+            
+                        trace!("registered event: {:?}", &event);
+                        let KeyEvent { code, modifiers: _ } = event;
+            
+                        match code {
+                            KeyCode::Enter => break,
+                            KeyCode::Char(c) => {
+                                replacement.push(c);
+                            },
+                            _ => continue,
+                        }
+                    }
+
+                    let bandaid = BandAid::new(&replacement, &suggestion.span);
+                    return Ok(Pick::Replacement(bandaid));
+                },
                 KeyCode::Char('?') => return Ok(Pick::Help),
                 x => {
                     trace!("Unexpected input {:?}", x);


### PR DESCRIPTION
It closes #13

@drahnr I hope it's pretty clean. But might there is a better way to read from terminal.

*I am not sure about multilane replacement.
*`user_input` function got pretty big.
```bash
[zhiburt@zhiburt scc]$ cargo spellcheck --interactivePath is /home/zhiburt/proj/scc/src/main.rs and has 5
error: spellcheck(Hunspell)
   --> /home/zhiburt/proj/scc/src/main.rs:29
    |
 29 |  Prints tokens which are produced by lexical analyzer to stdout
    |                                                          ^^^^^^
    | - stout, std out, std-out, standout, outdoes, o
(1/5) Apply this suggestion [y,n,q,a,d,j,e,?]?

   outdo
   outdoors
   outdoes
   standout
   std-out
   std out
 » stout

replacement: My first PR to cargo-spellcheck
...
```