### PR TITLE
fix/interactive: terminal resize while waiting user input caused crash

### DIFF
--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -241,6 +241,10 @@ impl UserPicked {
                 .map_err(|e| anyhow::anyhow!("Something unexpected happened on the CLI: {}", e))?
             {
                 Event::Key(event) => event,
+                Event::Resize(..) => {
+                    drop(guard);
+                    continue
+                }
                 sth => {
                     trace!("read() something other than a key: {:?}", sth);
                     break;


### PR DESCRIPTION
If user's terminal got resized in `interactive` mode he/she would get a panic.

```
thread 'main' panicked at 'internal error: entered unreachable code: Unexpected return when dealing with user input', src/action/interactive.rs:320:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
I believe #23 shall be changed too to track the resize properly
