### PR TITLE
fix/hunspell: remove debug message

### DIFF
--- a/src/checker/hunspell.rs
+++ b/src/checker/hunspell.rs
@@ -21,7 +21,7 @@ impl Checker for HunspellChecker {
         //     }
         // };
 
-        let search_dirs = dbg!(config.search_dirs());
+        let search_dirs = config.search_dirs();
 
         let lang = config.lang();
 


### PR DESCRIPTION
I bet it's unnecessary to put at output at least by `dbg!` :)