### PR TITLE
Fix interactive chose movements

### DIFF
--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -171,8 +171,8 @@ impl UserPicked {
         let KeyEvent { code, modifiers } = event;
 
         match code {
-            KeyCode::Up => state.select_previous(),
-            KeyCode::Down => state.select_next(),
+            KeyCode::Up => state.select_next(),
+            KeyCode::Down => state.select_previous(),
             KeyCode::Enter => {
                 let bandaid = BandAid::new(&state.custom_replacement, &state.suggestion.span);
                 return Ok(Pick::Replacement(bandaid));


### PR DESCRIPTION
When custom input is chosen the movements were mixed up.


 @drahnr sorry for the delay in the fixes I had to do :). #30 Looks great.
And as #23 is closed I'd like to say thank you for `Good first issue` labels :)