### PR TITLE
feature/interactive: add insert mode

### DIFF
--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -192,6 +192,14 @@ impl UserPicked {
                 state.cursor_index = state.custom_replacement.len() as u16;
                 state.select_previous();
             }
+            KeyCode::Backspace => {
+                if state.cursor_index > 0 {
+                    state.cursor_index -= 1;
+                    state
+                        .custom_replacement
+                        .remove(state.cursor_index as usize);
+                }
+            }
             KeyCode::Enter => {
                 let bandaid = BandAid::new(&state.custom_replacement, &state.suggestion.span);
                 return Ok(Pick::Replacement(bandaid));

--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -82,9 +82,9 @@ where
     pub suggestion: &'s Suggestion<'t>,
     /// The content the user provided for the suggestion, if any.
     pub custom_replacement: String,
-    pub i_custom_replacement_end_index: (u16, u16),
-    pub i_custom_replacement_start_column: u16,
-    pub i_cursor_index: u16,
+    pub custom_replacement_row: u16,
+    pub custom_replacement_start_column: u16,
+    pub cursor_index: u16,
     /// Which index to show as highlighted.
     pub pick_idx: usize,
     /// Total number of pickable slots.
@@ -96,9 +96,9 @@ impl<'s, 't> From<&'s Suggestion<'t>> for State<'s, 't> {
         Self {
             suggestion,
             custom_replacement: String::new(),
-            i_custom_replacement_end_index: (0, 0),
-            i_custom_replacement_start_column: 0,
-            i_cursor_index: 0,
+            custom_replacement_row: 0,
+            custom_replacement_start_column: 0,
+            cursor_index: 0,
             pick_idx: 0usize,
             // all items provided by the checkers plus the user provided
             n_items: suggestion.replacements.len() + 1,
@@ -178,18 +178,18 @@ impl UserPicked {
 
         match code {
             KeyCode::Left => {
-                state.i_cursor_index = state.i_cursor_index.checked_sub(1).unwrap_or_default()
+                state.cursor_index = state.cursor_index.checked_sub(1).unwrap_or_default()
             }
             KeyCode::Right => {
-                state.i_cursor_index =
-                    (state.i_cursor_index + 1).min(state.custom_replacement.len() as u16)
+                state.cursor_index =
+                    (state.cursor_index + 1).min(state.custom_replacement.len() as u16)
             }
             KeyCode::Up => {
-                state.i_cursor_index = state.custom_replacement.len() as u16;
+                state.cursor_index = state.custom_replacement.len() as u16;
                 state.select_next();
             }
             KeyCode::Down => {
-                state.i_cursor_index = state.custom_replacement.len() as u16;
+                state.cursor_index = state.custom_replacement.len() as u16;
                 state.select_previous();
             }
             KeyCode::Enter => {
@@ -201,9 +201,9 @@ impl UserPicked {
             KeyCode::Char(c) => {
                 state
                     .custom_replacement
-                    .insert(state.i_cursor_index as usize, c);
-                state.i_cursor_index += 1;
-            } // @todo handle cursors and insert / delete mode
+                    .insert(state.cursor_index as usize, c);
+                state.cursor_index += 1;
+            }
             _ => {}
         }
 
@@ -282,8 +282,8 @@ impl UserPicked {
         }
         let _ = stdout.flush();
 
-        state.i_custom_replacement_end_index = cursor::position().unwrap();
-        state.i_custom_replacement_start_column = 3;
+        state.custom_replacement_row = cursor::position()?.1;
+        state.custom_replacement_start_column = 3;
 
         state
             .suggestion
@@ -398,8 +398,8 @@ impl UserPicked {
                     .queue(cursor::Show)
                     .unwrap()
                     .queue(cursor::MoveTo(
-                        state.i_cursor_index + state.i_custom_replacement_start_column,
-                        state.i_custom_replacement_end_index.1,
+                        state.cursor_index + state.custom_replacement_start_column,
+                        state.custom_replacement_row,
                     ))
                     .unwrap();
                 stdout().flush().unwrap();

--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -174,13 +174,8 @@ impl UserPicked {
 
         let length = state.custom_replacement.len() as u16;
         match code {
-            KeyCode::Left => {
-                state.cursor_offset = state.cursor_offset.saturating_sub(1)
-            }
-            KeyCode::Right => {
-                state.cursor_offset =
-                    (state.cursor_offset + 1).min(length)
-            }
+            KeyCode::Left => state.cursor_offset = state.cursor_offset.saturating_sub(1),
+            KeyCode::Right => state.cursor_offset = (state.cursor_offset + 1).min(length),
             KeyCode::Up => {
                 state.cursor_offset = length;
                 state.select_next();

--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -82,9 +82,7 @@ where
     pub suggestion: &'s Suggestion<'t>,
     /// The content the user provided for the suggestion, if any.
     pub custom_replacement: String,
-    pub custom_replacement_row: u16,
-    pub custom_replacement_start_column: u16,
-    pub cursor_index: u16,
+    pub cursor_offset: u16,
     /// Which index to show as highlighted.
     pub pick_idx: usize,
     /// Total number of pickable slots.
@@ -96,9 +94,7 @@ impl<'s, 't> From<&'s Suggestion<'t>> for State<'s, 't> {
         Self {
             suggestion,
             custom_replacement: String::new(),
-            custom_replacement_row: 0,
-            custom_replacement_start_column: 0,
-            cursor_index: 0,
+            cursor_offset: 0,
             pick_idx: 0usize,
             // all items provided by the checkers plus the user provided
             n_items: suggestion.replacements.len() + 1,
@@ -176,28 +172,29 @@ impl UserPicked {
     fn custom_replacement(&self, state: &mut State, event: KeyEvent) -> Result<Pick> {
         let KeyEvent { code, modifiers } = event;
 
+        let length = state.custom_replacement.len() as u16;
         match code {
             KeyCode::Left => {
-                state.cursor_index = state.cursor_index.checked_sub(1).unwrap_or_default()
+                state.cursor_offset = state.cursor_offset.saturating_sub(1)
             }
             KeyCode::Right => {
-                state.cursor_index =
-                    (state.cursor_index + 1).min(state.custom_replacement.len() as u16)
+                state.cursor_offset =
+                    (state.cursor_offset + 1).min(length)
             }
             KeyCode::Up => {
-                state.cursor_index = state.custom_replacement.len() as u16;
+                state.cursor_offset = length;
                 state.select_next();
             }
             KeyCode::Down => {
-                state.cursor_index = state.custom_replacement.len() as u16;
+                state.cursor_offset = length;
                 state.select_previous();
             }
             KeyCode::Backspace => {
-                if state.cursor_index > 0 {
-                    state.cursor_index -= 1;
+                if state.cursor_offset > 0 {
+                    state.cursor_offset -= 1;
                     state
                         .custom_replacement
-                        .remove(state.cursor_index as usize);
+                        .remove(state.cursor_offset as usize);
                 }
             }
             KeyCode::Enter => {
@@ -209,8 +206,8 @@ impl UserPicked {
             KeyCode::Char(c) => {
                 state
                     .custom_replacement
-                    .insert(state.cursor_index as usize, c);
-                state.cursor_index += 1;
+                    .insert(state.cursor_offset as usize, c);
+                state.cursor_offset += 1;
             }
             _ => {}
         }
@@ -289,9 +286,6 @@ impl UserPicked {
                 .unwrap();
         }
         let _ = stdout.flush();
-
-        state.custom_replacement_row = cursor::position()?.1;
-        state.custom_replacement_start_column = 3;
 
         state
             .suggestion
@@ -405,10 +399,9 @@ impl UserPicked {
                 stdout()
                     .queue(cursor::Show)
                     .unwrap()
-                    .queue(cursor::MoveTo(
-                        state.cursor_index + state.custom_replacement_start_column,
-                        state.custom_replacement_row,
-                    ))
+                    .queue(cursor::MoveToPreviousLine(1))
+                    .unwrap()
+                    .queue(cursor::MoveToColumn(4 + state.cursor_offset))
                     .unwrap();
                 stdout().flush().unwrap();
             }


### PR DESCRIPTION
This adds a cursor movement and inserting a character in *arbitrary* place.

Truly saying I got confused implementing that in order of complexity.
Might it would be better to split responsibilities of rendering the general list of suggestions from the custom line.
In this case there would be no need in rendering the whole suggestion list one more time.
And the complexity would be reduced just because each part of interface is responsible for one thing. (I see that it's what should have been done but ... :)).

yep. I consider the code this PR providing is slightly compound :(

PS: These thoughts I have in order to not thinking that my code *just* bad :smiley: 