### PR TITLE
feat/signals: exit raw terminal mode on SIGTERM, SIGINT etc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "serde",
  "signal-hook",
  "syn",
+ "termios",
  "toml",
  "url 2.1.1",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "pulldown-cmark",
  "regex",
  "serde",
+ "signal-hook",
  "syn",
  "toml",
  "url 2.1.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ itertools = "0.9"
 crossterm = "0.17"
 regex = "1"
 signal-hook = "0.1"
+termios = "0.3"
 
 # config parsing, must be independent of features
 iso_country = { version = "0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ pulldown-cmark = "0.7"
 itertools = "0.9"
 crossterm = "0.17"
 regex = "1"
+signal-hook = "0.1"
 
 # config parsing, must be independent of features
 iso_country = { version = "0.1" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,10 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    std::thread::spawn(move || signal_handler());
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::thread::spawn(move || signal_handler());
+    }
 
     let checkers = |config: &mut Config| {
         // overwrite checkers

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,13 @@ struct Args {
     cmd_config: bool,
 }
 
+fn on_exit() {
+    match crossterm::terminal::disable_raw_mode() {
+        Ok(_) => std::process::exit(130),
+        Err(_) => std::process::exit(1),
+    };
+}
+
 fn parse_args(mut argv_iter: impl Iterator<Item = String>) -> Result<Args, docopt::Error> {
     Docopt::new(USAGE).and_then(|d| {
         // if ends with file name `cargo-spellcheck`, split
@@ -131,10 +138,6 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let on_exit = || match crossterm::terminal::disable_raw_mode() {
-        Ok(_) => std::process::exit(0),
-        Err(_) => std::process::exit(1),
-    };
 
     let signals = iterator::Signals::new(vec![SIGTERM, SIGINT, SIGQUIT])?;
     std::thread::spawn(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,12 +70,16 @@ struct Args {
     cmd_config: bool,
 }
 
+#[cfg(not(target_os="linux"))]
 fn on_exit(state: termios::Termios, fd: i32) {
     match termios::tcsetattr(fd, termios::TCSAFLUSH, &state) {
         Ok(_) => std::process::exit(130),
         Err(_) => std::process::exit(1),
     };
 }
+
+#[cfg(target_os = "windows")]
+fn on_exit(state: termios::Termios, fd: i32) {}
 
 fn parse_args(mut argv_iter: impl Iterator<Item = String>) -> Result<Args, docopt::Error> {
     Docopt::new(USAGE).and_then(|d| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ fn main() -> anyhow::Result<()> {
 
     let signals = iterator::Signals::new(vec![SIGTERM, SIGINT, SIGQUIT])?;
     std::thread::spawn(move || {
-        const STDIN_FILENO: i32 = 0;
+        let stdin =  std::io::stdin().as_raw_fd(); // unix only
         let mut termios_orig = termios::Termios::from_fd(STDIN_FILENO).unwrap();
         termios::tcgetattr(STDIN_FILENO, &mut termios_orig)
             .expect("Failed to obtain terminal settings");

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ fn signal_handler() {
                     std::process::exit(130);
                 }
             }
-            _ => unreachable!(),
+            sig => warn!("Received unhandled signal {}, ignoring", sig),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use docopt::Docopt;
 
 use log::{info, trace, warn};
 use serde::Deserialize;
-use signal_hook::{iterator, SIGTERM, SIGINT, SIGQUIT};
+use signal_hook::{iterator, SIGINT, SIGQUIT, SIGTERM};
 
 use std::path::PathBuf;
 
@@ -131,11 +131,9 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let on_exit = || {
-        match crossterm::terminal::disable_raw_mode() {
-            Ok(_) => std::process::exit(0),
-            Err(_) => std::process::exit(1),
-        }
+    let on_exit = || match crossterm::terminal::disable_raw_mode() {
+        Ok(_) => std::process::exit(0),
+        Err(_) => std::process::exit(1),
     };
 
     let signals = iterator::Signals::new(vec![SIGTERM, SIGINT, SIGQUIT])?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,12 +103,6 @@ fn signal_handler() {
     }
 }
 
-#[cfg(target_os = "windows")]
-fn on_exit(state: termios::Termios, fd: i32) -> Result<(), std::io::Error> {}
-
-#[cfg(target_os = "windows")]
-fn signal_handler() {}
-
 fn parse_args(mut argv_iter: impl Iterator<Item = String>) -> Result<Args, docopt::Error> {
     Docopt::new(USAGE).and_then(|d| {
         // if ends with file name `cargo-spellcheck`, split


### PR DESCRIPTION
## What does this PR accomplish?

closes #34  .

## Changes proposed by this PR:

Add a signal-hook for `SIGINT`, `SIGTERM` and `SIGQUIT` (not sure here) to properly disable raw terminal mode.

## Notes to reviewer:

How is this testable? Manual testing showed it's working.

I'm not hundert percent happy with`on_exit()`, is the exit ok that way?