### PR TITLE
Simplified signal handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,6 @@ dependencies = [
  "serde",
  "signal-hook",
  "syn",
- "termios",
  "toml",
  "url 2.1.1",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ itertools = "0.9"
 crossterm = "0.17"
 regex = "1"
 signal-hook = "0.1"
-termios = "0.3"
 
 # config parsing, must be independent of features
 iso_country = { version = "0.1" }

--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -197,7 +197,10 @@ impl UserPicked {
             }
             KeyCode::Esc => return Ok(Pick::Quit),
             KeyCode::Char('c') if modifiers == KeyModifiers::CONTROL => {
-                return Err(anyhow!("Received SIGINT"))
+                crossterm::terminal::disable_raw_mode()?;
+                std::io::stdout().queue(crossterm::cursor::Show)?;
+                std::io::stdout().flush()?;
+                std::process::exit(130);
             }
             KeyCode::Char(c) => {
                 state
@@ -442,7 +445,10 @@ impl UserPicked {
                 KeyCode::Char('n') => return Ok(Pick::Skip),
                 KeyCode::Char('j') => return Ok(Pick::Previous),
                 KeyCode::Char('c') if modifiers == KeyModifiers::CONTROL => {
-                    return Err(anyhow!("Received SIGINT"))
+                    crossterm::terminal::disable_raw_mode()?;
+                    std::io::stdout().queue(crossterm::cursor::Show)?;
+                    std::io::stdout().flush()?;
+                    std::process::exit(130);
                 }
                 KeyCode::Char('q') | KeyCode::Esc => return Ok(Pick::Quit),
                 KeyCode::Char('d') => return Ok(Pick::SkipFile),

--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -196,7 +196,9 @@ impl UserPicked {
                 return Ok(Pick::Replacement(bandaid));
             }
             KeyCode::Esc => return Ok(Pick::Quit),
-            KeyCode::Char('c') if modifiers == KeyModifiers::CONTROL => return Ok(Pick::Quit),
+            KeyCode::Char('c') if modifiers == KeyModifiers::CONTROL => {
+                return Err(anyhow!("Received SIGINT"))
+            }
             KeyCode::Char(c) => {
                 state
                     .custom_replacement
@@ -439,7 +441,9 @@ impl UserPicked {
                 }
                 KeyCode::Char('n') => return Ok(Pick::Skip),
                 KeyCode::Char('j') => return Ok(Pick::Previous),
-                KeyCode::Char('c') if modifiers == KeyModifiers::CONTROL => return Ok(Pick::Quit),
+                KeyCode::Char('c') if modifiers == KeyModifiers::CONTROL => {
+                    return Err(anyhow!("Received SIGINT"))
+                }
                 KeyCode::Char('q') | KeyCode::Esc => return Ok(Pick::Quit),
                 KeyCode::Char('d') => return Ok(Pick::SkipFile),
                 KeyCode::Char('e') => {

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -197,7 +197,7 @@ impl Action {
         for (_path, suggestions) in suggestions_per_path {
             count += suggestions.len();
             for suggestion in suggestions {
-                eprintln!("{}", suggestion);
+                println!("{}", suggestion);
             }
         }
         if count > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,10 @@ pub use self::suggestion::*;
 
 use docopt::Docopt;
 
-use crossterm::QueueableCommand;
 use log::{info, trace, warn};
 use serde::Deserialize;
 use signal_hook::{iterator, SIGINT, SIGQUIT, SIGTERM};
 
-use std::io::{stdout, Write};
 use std::path::PathBuf;
 
 const USAGE: &str = r#"
@@ -72,11 +70,6 @@ struct Args {
     cmd_config: bool,
 }
 
-fn exit() -> Result<(), anyhow::Error> {
-    stdout().queue(crossterm::cursor::Show)?;
-    crossterm::terminal::disable_raw_mode()?;
-    stdout().flush().map_err(|e| anyhow::anyhow!(e))
-}
 
 fn signal_handler() {
     let signals =
@@ -84,7 +77,7 @@ fn signal_handler() {
     for s in signals.forever() {
         match s {
             SIGTERM | SIGINT | SIGQUIT => {
-                if exit().is_err() {
+                if action::interactive::ScopedRaw::restore_terminal().is_err() {
                     std::process::exit(1);
                 } else {
                     std::process::exit(130);

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,8 @@ use log::{info, trace, warn};
 use serde::Deserialize;
 use signal_hook::{iterator, SIGINT, SIGQUIT, SIGTERM};
 
-use std::path::PathBuf;
 use std::io::{stdout, Write};
+use std::path::PathBuf;
 
 const USAGE: &str = r#"
 Spellcheck all your doc comments

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,14 +72,12 @@ struct Args {
     cmd_config: bool,
 }
 
-#[cfg(not(target_os = "windows"))]
 fn exit() -> Result<(), anyhow::Error> {
     stdout().queue(crossterm::cursor::Show)?;
     crossterm::terminal::disable_raw_mode()?;
     stdout().flush().map_err(|e| anyhow::anyhow!(e))
 }
 
-#[cfg(not(target_os = "windows"))]
 fn signal_handler() {
     let signals =
         iterator::Signals::new(vec![SIGTERM, SIGINT, SIGQUIT]).expect("Failed to create Signals");
@@ -158,10 +156,7 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    #[cfg(not(target_os = "windows"))]
-    {
-        std::thread::spawn(move || signal_handler());
-    }
+    std::thread::spawn(move || signal_handler());
 
     let checkers = |config: &mut Config| {
         // overwrite checkers

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,18 +70,16 @@ struct Args {
     cmd_config: bool,
 }
 
-
 fn signal_handler() {
     let signals =
         iterator::Signals::new(vec![SIGTERM, SIGINT, SIGQUIT]).expect("Failed to create Signals");
     for s in signals.forever() {
         match s {
             SIGTERM | SIGINT | SIGQUIT => {
-                if action::interactive::ScopedRaw::restore_terminal().is_err() {
-                    std::process::exit(1);
-                } else {
-                    std::process::exit(130);
+                if let Err(e) = action::interactive::ScopedRaw::restore_terminal() {
+                    warn!("Failed to restore terminal: {}", e);
                 }
+                std::process::exit(130);
             }
             sig => warn!("Received unhandled signal {}, ignoring", sig),
         }


### PR DESCRIPTION
## What does this PR accomplish?

closes #34 eventually and fixes #59 which was introduced in #58 .

Added the fix for #60 since its just one character..

## Changes proposed by this PR:

The current implementation does not restore the cursor on `SIGINT`, `SIGTERM` and `SIGQUIT`. It also does not work when in interactive mode. To simplify things, I removed the `termios` dep and solely restore the `crossterm` and `std::io::stdout` internal changed in the first place when entered interactive mode.

One drawback: hitting `ctrl+c` in interactive mode leads to exit code `1` instead of `130`. Should we fix this?