### PR TITLE
add a suggestion format test + fix basic single line formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ hunspell-rs = { version = "0.1", optional = true }
 # full grammar check
 languagetool-rs = { version = "0.1", package = "languagetool", optional = true }
 
+
+[dev-dependencies]
+# for stripping ansi color codes
+console = "0.11"
+
 [features]
 default = ["hunspell"]
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,15 @@
 
 Check your spelling with `hunspell` and/or `languagetool`.
 
-## Usecase
+## Use Cases
 
 Run `cargo spellcheck --fix` or `cargo spellcheck fix` to fix all your documentation comments
 in order to avoid narsty types all over the place.
 
 Meant as a helper simplifying review as well as possibly improving CI
 after a learning phase for custom/topic specifc lingo.
-`cargo spellcheck` has a return code `1` if any unknown words are found, and `0` on success.
 
-## Use Cases
-
-### Check
+### Check For Spelling and/or Grammar Mistakes
 
 ```zsh
 cargo spellcheck check
@@ -32,7 +29,7 @@ cargo spellcheck check
 <font color="#3465A4"><b>    |</b></font>
 </pre>
 
-### Interactive fixing
+### Apply Suggestions Interactively
 
 ```zsh
 cargo spellcheck fix --interactive
@@ -56,6 +53,11 @@ cargo spellcheck fix --interactive
  <font color="#8AE234"><b>»</b></font> <span style="background-color:#2E3436"><font color="#FCE94F">a custom replacement literal</font></span>
 </pre>
 
+### Continuous Integration / CI
+
+`cargo spellcheck` can be configured with `-m <code>` to return a non-zero return code if
+mistakes are found instead of `0`.
+
 ## Implemented Features + Roadmap
 
 * [x] Parse doc comments from arbitrary files
@@ -63,13 +65,14 @@ cargo spellcheck fix --interactive
 * [x] `cargo-spellcheck check`
 * [x] Spell checking using `hunspell`
 * [x] Merge multiline doc comments
+* [ ] Properly handle grammar mistakes spanning accross multiple lines
 * [x] Grammar check using `languagetool` http API
-* [x] False positive reduction
 * [x] Follow module declarations rather than blindly recurse
 * [x] Be `markdown` aware
   * [ ] Handle doctests with ` ```rust` as virtual files [#43](https://github.com/drahnr/cargo-spellcheck/issues/43)
   * [ ] Verify all types of links [#44](https://github.com/drahnr/cargo-spellcheck/issues/44)
 * [ ] Check `README.md` files [#37](https://github.com/drahnr/cargo-spellcheck/issues/37)
+* [ ] Check mdbook `book.toml` file trees [#62](https://github.com/drahnr/cargo-spellcheck/issues/62)
 * [x] `cargo-spellcheck fix --interactive`
 * [x] Improve interactive user interface with `crossterm`
 * [ ] Ellipsize overly long statements with `...` [#42](https://github.com/drahnr/cargo-spellcheck/issues/42)
@@ -108,23 +111,25 @@ extra_dictonaries = []
 To increase verbosity use `CARGO_SPELLCHECK=cargo_spellcheck=trace` to see internal details or
 add `-v` (multiple) to increase verbosity.
 
+Windows currently suffers from an issue of the inability to build `hunspell` (the C lib) easily on windows or specify where it exists, see [#14](https://github.com/drahnr/cargo-spellcheck/issues/14) for details, there is an upcoming upstream fix in [hunspell-sys/#2](https://github.com/euclio/hunspell-sys/pull/2).
+
 ### Hunspell
 
 Requires the native library
 
 ```sh
 # Fedora 30+
-dnf install -y hunspell-devel
+dnf install -y hunspell-devel clang
 
 # Ubuntu 19.10+
-apt install -y libhunspell-dev
+apt install -y libhunspell-dev clang
 
 # Mac OS X
-brew install hunspell
+brew install hunspell llvm
 ```
 
 and building should succeed just fine.
 
 ### LanguageTool
 
-Run a instance of the [LanguageTool server i.e. as container](https://hub.docker.com/r/erikvl87/languagetool) .
+Run a instance of the [LanguageTool server i.e. as container](https://hub.docker.com/r/erikvl87/languagetool).

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -138,6 +138,8 @@ impl Action {
             ContentOrigin::RustSourceFile(path) => self.correct_file(path, bandaids),
             //@todo bandaids are relative to the doc-test, so fix the span with the one provided
             ContentOrigin::RustDocTest(path, _span) => self.correct_file(path, bandaids),
+            #[cfg(test)]
+            ContentOrigin::TestEntity => unreachable!("Use a proper file"),
         }
     }
 

--- a/src/checker/dummy.rs
+++ b/src/checker/dummy.rs
@@ -38,6 +38,7 @@ impl Checker for DummyChecker {
                         let suggestion = Suggestion {
                             detector,
                             span,
+                            range,
                             origin: origin.clone(),
                             replacements,
                             chunk,

--- a/src/checker/hunspell.rs
+++ b/src/checker/hunspell.rs
@@ -123,11 +123,12 @@ impl Checker for HunspellChecker {
                                 .filter(|x| x.len() > 1) // single char suggestions tend to be useless
                                 .collect::<Vec<_>>();
 
-                            for (_range, span) in plain.find_spans(range.clone()) {
+                            for (range, span) in plain.find_spans(range.clone()) {
                                 acc.add(
                                     origin.clone(),
                                     Suggestion {
                                         detector: Detector::Hunspell,
+                                        range,
                                         span,
                                         origin: origin.clone(),
                                         replacements: replacements.clone(),

--- a/src/checker/languagetool.rs
+++ b/src/checker/languagetool.rs
@@ -43,7 +43,7 @@ impl Checker for LanguageToolChecker {
                             trace!("item.message: {:?}", item.message);
                             trace!("item.short_message: {:?}", item.short_message);
                             // TODO convert response to offsets and errors with the matching literal
-                            for (_range, span) in plain.find_spans(Range {
+                            for (range, span) in plain.find_spans(Range {
                                 start: item.offset as usize,
                                 end: (item.offset + item.length) as usize,
                             }) {
@@ -51,6 +51,7 @@ impl Checker for LanguageToolChecker {
                                     origin.clone(),
                                     Suggestion {
                                         detector: Detector::LanguageTool,
+                                        range,
                                         span,
                                         origin: origin.clone(),
                                         replacements: item

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -27,7 +27,7 @@ impl ContentOrigin {
             Self::RustSourceFile(path) => path.as_path(),
             #[cfg(test)]
             Self::TestEntity => {
-                lazy_static::lazy_static!{
+                lazy_static::lazy_static! {
                     static ref TEST_ENTITY: PathBuf = PathBuf::from("/tmp/test/entity");
                 };
                 TEST_ENTITY.as_path()

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -15,6 +15,8 @@ pub enum ContentOrigin {
     CommonMarkFile(PathBuf),
     RustDocTest(PathBuf, Span), // span is just there to disambiguiate
     RustSourceFile(PathBuf),
+    #[cfg(test)]
+    TestEntity,
 }
 
 impl ContentOrigin {
@@ -23,6 +25,13 @@ impl ContentOrigin {
             Self::CommonMarkFile(path) => path.as_path(),
             Self::RustDocTest(path, _) => path.as_path(),
             Self::RustSourceFile(path) => path.as_path(),
+            #[cfg(test)]
+            Self::TestEntity => {
+                lazy_static::lazy_static!{
+                    static ref TEST_ENTITY: PathBuf = PathBuf::from("/tmp/test/entity");
+                };
+                TEST_ENTITY.as_path()
+            }
         }
     }
 }

--- a/src/documentation/mod.rs
+++ b/src/documentation/mod.rs
@@ -167,50 +167,45 @@ mod tests {
             )
         };
 
-        ($test:expr, $n:expr, $origin:expr) => {
-            {
-                let _ = env_logger::from_env(
-                    env_logger::Env::new().filter_or("CARGO_SPELLCHECK", "cargo_spellcheck=trace"),
-                )
-                .is_test(true)
-                .try_init();
+        ($test:expr, $n:expr, $origin:expr) => {{
+            let _ = env_logger::from_env(
+                env_logger::Env::new().filter_or("CARGO_SPELLCHECK", "cargo_spellcheck=trace"),
+            )
+            .is_test(true)
+            .try_init();
 
-                let origin = $origin;
-                let stream =
-                    syn::parse_str::<proc_macro2::TokenStream>($test).expect("Must be valid rust");
-                let docs = Documentation::from((origin.clone(), stream));
-                assert_eq!(docs.index.len(), 1);
-                let chunks = docs.index.get(&origin).expect("Must contain dummy path");
-                assert_eq!(dbg!(chunks).len(), 1);
-                let chunk = &chunks[0];
-                let _plain = chunk.erase_markdown();
+            let origin = $origin;
+            let stream =
+                syn::parse_str::<proc_macro2::TokenStream>($test).expect("Must be valid rust");
+            let docs = Documentation::from((origin.clone(), stream));
+            assert_eq!(docs.index.len(), 1);
+            let chunks = docs.index.get(&origin).expect("Must contain dummy path");
+            assert_eq!(dbg!(chunks).len(), 1);
+            let chunk = &chunks[0];
+            let _plain = chunk.erase_markdown();
 
-                let suggestion_set = crate::checker::dummy::DummyChecker::check(&docs, &())
-                    .expect("Must not fail to extract suggestions");
-                let (_, suggestions) = suggestion_set
-                    .iter()
-                    .next()
-                    .expect("Must contain exactly one item");
-                assert_eq!(dbg!(suggestions).len(), $n);
-                suggestion_set
-            }
-        };
+            let suggestion_set = crate::checker::dummy::DummyChecker::check(&docs, &())
+                .expect("Must not fail to extract suggestions");
+            let (_, suggestions) = suggestion_set
+                .iter()
+                .next()
+                .expect("Must contain exactly one item");
+            assert_eq!(dbg!(suggestions).len(), $n);
+            suggestion_set
+        }};
     }
 
     macro_rules! end2end_file {
-        ($path: literal, $n: expr) => {
-            {
-                let path2 = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/", $path));
-                let origin = ContentOrigin::RustSourceFile(path2);
-                end2end!(
-                    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", $path)),
-                    $n,
-                    origin
-                )
-            }
-        };
+        ($path: literal, $n: expr) => {{
+            let path2 = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/", $path));
+            let origin = ContentOrigin::RustSourceFile(path2);
+            end2end!(
+                include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", $path)),
+                $n,
+                origin
+            )
+        }};
     }
-
 
     #[test]
     fn one_line() {

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -93,8 +93,9 @@ impl<'s> fmt::Display for Suggestion<'s> {
 
         let x = self.span.start.line;
         let (path, line) = match self.origin {
-            ContentOrigin::RustDocTest(ref path, ref span) =>
-                (path.display().to_string(), x + span.start.line),
+            ContentOrigin::RustDocTest(ref path, ref span) => {
+                (path.display().to_string(), x + span.start.line)
+            }
             ref origin => (origin.as_path().display().to_string(), x),
         };
         writeln!(formatter, " {path}:{line}", path = path, line = line)?;
@@ -365,14 +366,12 @@ impl<'s> IntoIterator for &'s SuggestionSet<'s> {
     }
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::LineColumn;
-    use std::fmt;
     use console;
+    use std::fmt;
     fn assert_display_eq<D: fmt::Display, S: AsRef<str>>(display: D, s: S) {
         let expected = s.as_ref();
         let expected = console::strip_ansi_codes(expected);
@@ -383,10 +382,8 @@ mod tests {
         assert_eq!(reality, expected);
     }
 
-
     #[test]
     fn fmt() {
-
         const CONTENT: &'static str = "Is it dyrck again?";
         let chunk = CheckableChunk::from_str(
             CONTENT,
@@ -400,31 +397,28 @@ mod tests {
                         column: 17,
                     }
                 }
-            }
+            },
         );
 
-        let suggestion= Suggestion {
+        let suggestion = Suggestion {
             detector: Detector::Dummy,
             origin: ContentOrigin::TestEntity,
             chunk: &chunk,
             span: Span {
-                start: LineColumn {
-                    line: 1,
-                    column: 6,
-                },
+                start: LineColumn { line: 1, column: 6 },
                 end: LineColumn {
                     line: 1,
                     column: 10,
-                }
+                },
             },
             replacements: vec!["replacement_0", "replacement_1", "replacement_2"]
-                .into_iter().map(std::borrow::ToOwned::to_owned).collect(),
+                .into_iter()
+                .map(std::borrow::ToOwned::to_owned)
+                .collect(),
             description: Some("Possible spelling mistake found.".to_owned()),
         };
 
-
-        const EXPECTED: &'static str =
-r#"error: spellcheck(Dummy)
+        const EXPECTED: &'static str = r#"error: spellcheck(Dummy)
   --> /tmp/test/entity:1
    |
  1 | Is it dyrck again?

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -59,8 +59,10 @@ pub struct Suggestion<'s> {
     pub origin: ContentOrigin,
     /// @todo must become a `CheckableChunk` and properly integrated
     pub chunk: &'s CheckableChunk,
-    /// The span (absolute!) of where it is supposed to be used.
+    /// The span (absolute!) within the file or chunk (depens on `origin`).
     pub span: Span,
+    /// Range relative to the chunk the current suggestion is located.
+    pub range: Range,
     /// Fix suggestions, might be words or the full sentence.
     pub replacements: Vec<String>,
     /// Descriptive reason for the suggestion.

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -424,12 +424,11 @@ mod tests {
 
 
         const EXPECTED: &'static str =
-r#"
-error: spellcheck(Dummy)
+r#"error: spellcheck(Dummy)
   --> /tmp/test/entity:1
    |
-1  |
-   |                                                   ^^^^
+ 1 | Is it dyrck again?
+   |       ^^^^^
    | - replacement_0, replacement_1 or replacement_2
    |
    |   Possible spelling mistake found.

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -11,13 +11,12 @@
 //!     |     - you can add it to your personal dictionary to prevent future alerts.
 //! ```
 
-use crate::{Span, Range};
 use crate::documentation::{CheckableChunk, ContentOrigin};
+use crate::{Range, Span};
 
 use std::convert::TryFrom;
 
 use enumflags2::BitFlags;
-
 
 /// Bitflag of available checkers by compilation / configuration.
 #[derive(Debug, Clone, Copy, BitFlags, Eq, PartialEq, Hash)]
@@ -117,11 +116,15 @@ impl<'s> fmt::Display for Suggestion<'s> {
         writeln!(formatter, " {}", self.chunk.as_str())?;
 
         // underline the relevant part with ^^^^^
-        let mut marker_size = if self.span.end.line == self.span.start.line {
+        let marker_size = if self.span.end.line == self.span.start.line {
             // column bounds are inclusive, so for a correct length we need to add + 1
             self.span.end.column.saturating_sub(self.span.start.column) + 1
         } else {
-            self.chunk.as_str().chars().count().saturating_sub(self.span.start.column)
+            self.chunk
+                .as_str()
+                .chars()
+                .count()
+                .saturating_sub(self.span.start.column)
         };
 
         // if the offset starts from 0, we still want to continue if the length


### PR DESCRIPTION
Avoids drift or regressions.

## What does this PR accomplish?

Add a test to avoid output regressions.

Makes #68 testable.

## Changes proposed by this PR:

Add an additional test case (just one for now).