### PR TITLE
docs/README: fix installation instruction for macOS with hunspell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ brew install hunspell llvm
 
 and building should succeed just fine.
 
+On macOS, set `llvm-config` executable path to `LLVM_CONFIG_PATH` environment variable.
+
+```
+LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config cargo install cargo-spellcheck
+```
+
 ### LanguageTool
 
 Run a instance of the [LanguageTool server i.e. as container](https://hub.docker.com/r/erikvl87/languagetool).


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->

 * [ ] Bug Fix
 * [ ] Feature
 * [x] Documentation

closes no issue.

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

I'm using macOS 10.14 and tried to install this tool by `cargo install` but I got 'llvm-config is not found' error on building hunspell-sys.

`brew install llvm` does not install LLVM tools into `$PATH` directory such as `/usr/local/bin` because they confuse LLVM toolchain Xcode installs by default. They are put in `/usr/local/opt/llvm/bin`. `llvm-config` is put in the directory and the path needs to be populated with `$LLVM_CONFIG_PATH` environment variable.

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

Nothing.