### PR TITLE
WIP: rewrap doc-comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "serde",
  "signal-hook",
  "syn",
+ "textwrap 0.12.1",
  "toml",
  "url 2.1.1",
  "walkdir",
@@ -265,7 +266,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
 ]
@@ -1797,6 +1798,15 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ itertools = "0.9"
 crossterm = "0.17"
 fancy-regex = "0.3"
 signal-hook = "0.1"
+textwrap = "0.12"
 
 
 # config parsing, must be independent of features

--- a/demo/src/nested/just_very_long.rs
+++ b/demo/src/nested/just_very_long.rs
@@ -1,9 +1,0 @@
-//! This module contains documentation thats is too long for one line and moreover,
-//! it spans over mulitple lines such that we can test our rewrapping algorithm. Smart,
-//! isn't it? Lorem ipsum and some more blanket text without any meaning
-//!
-//! But lets also see what happens if there are two consecutive newlines in one connected
-//! documentation span.
-
-/// This is short.
-struct X;

--- a/demo/src/nested/just_very_long.rs
+++ b/demo/src/nested/just_very_long.rs
@@ -1,0 +1,8 @@
+//! This module contains documentation thats is too long for one line and moreover,
+//! it spans over mulitple lines such that we can test our rewrapping algorithm. Smart,
+//! isn't it? Lorem ipsum and some more blanket text without any meaning
+//!
+//! But lets also see what happens if there are two conesctutive newlines in one connected
+//! documentation span.
+
+struct X;

--- a/demo/src/nested/just_very_long.rs
+++ b/demo/src/nested/just_very_long.rs
@@ -2,7 +2,8 @@
 //! it spans over mulitple lines such that we can test our rewrapping algorithm. Smart,
 //! isn't it? Lorem ipsum and some more blanket text without any meaning
 //!
-//! But lets also see what happens if there are two conesctutive newlines in one connected
+//! But lets also see what happens if there are two consecutive newlines in one connected
 //! documentation span.
 
+/// This is short.
 struct X;

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@
 //! location by default. Default. Default default default.
 
 use crate::suggestion::Detector;
+use crate::wrap::WrapConfig;
 use anyhow::{anyhow, bail, Error, Result};
 use fancy_regex::Regex;
 use log::trace;
@@ -16,12 +17,14 @@ use std::fs::File;
 use std::io::Read;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Config {
     #[serde(rename = "Hunspell")]
     pub hunspell: Option<HunspellConfig>,
     #[serde(rename = "LanguageTool")]
     pub languagetool: Option<LanguageToolConfig>,
+    wrapper: Option<WrapConfig>,
 }
 
 #[derive(Debug)]
@@ -328,6 +331,7 @@ impl Config {
         match detector {
             Detector::Hunspell => self.hunspell.is_some(),
             Detector::LanguageTool => self.languagetool.is_some(),
+            Detector::Wrapper => self.wrapper.is_some(),
             #[cfg(test)]
             Detector::Dummy => true,
         }
@@ -374,6 +378,7 @@ impl Default for Config {
                 quirks: Some(Quirks::default()),
             }),
             languagetool: None,
+            wrapper: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod span;
 mod suggestion;
 mod traverse;
 mod util;
+mod wrap;
 
 pub use self::action::*;
 pub use self::config::{Config, HunspellConfig, LanguageToolConfig};

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -26,6 +26,7 @@ use crate::{Range, Span};
 pub enum Detector {
     Hunspell = 0b0001,
     LanguageTool = 0b0010,
+    Wrapper = 0b0100,
     #[cfg(test)]
     Dummy = 0b1000,
 }
@@ -63,6 +64,7 @@ impl fmt::Display for Detector {
         formatter.write_str(match self {
             Self::LanguageTool => "LanguageTool",
             Self::Hunspell => "Hunspell",
+            Self::Wrapper => "Wrapper",
             #[cfg(test)]
             Self::Dummy => "Dummy",
         })

--- a/src/wrap/mod.rs
+++ b/src/wrap/mod.rs
@@ -3,11 +3,16 @@
 //! Re-wrap doc comments for prettier styling in code
 
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 
+use crate::checker::Checker;
 use crate::Documentation;
+use crate::{Detector, Suggestion, SuggestionSet};
+use crate::Span;
+use crate::LineColumn;
 
 /// Parameters for wrapping doc comments
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WrapConfig {
     /// Hard limit for absolute length of lines
     max_line_length: usize,
@@ -15,28 +20,65 @@ pub struct WrapConfig {
 
 impl Default for WrapConfig {
     fn default() -> Self {
-        WrapConfig { max_line_length: 70 }
+        WrapConfig {
+            max_line_length: 70,
+        }
     }
 }
 
 #[derive(Debug)]
-pub struct Wrap {}
+pub struct Wrapper {}
 
-impl Wrap {
-    pub fn rewrap(doc: Documentation, config: Option<WrapConfig>) -> Result<()> {
-        let config = config.unwrap_or_default();
-        // loop through files
-        for (origin, chunks) in doc.iter() {
-            // loop through chunks a.k.a one conn
-            for chunk in chunks {
-                let new_chunks: Vec<String> = chunk.as_str().split("\n\n").collect::<Vec<&str>>().iter().map(|s| {
-                    let comment = s.replace("\n", "");
-                    textwrap::fill(&comment, config.max_line_length)
-                }).collect();
-                println!("{:?}", new_chunks.first());
-            }
-        }
-        Ok(())
+impl Checker for Wrapper {
+    type Config = WrapConfig;
+    fn check<'a, 's>(docu: &'a Documentation, config: &Self::Config) -> Result<SuggestionSet<'s>>
+    where
+        'a: 's,
+    {
+        let wrapper = textwrap::Wrapper::new(config.max_line_length)
+            .subsequent_indent(" ")
+            .initial_indent(" ");
+        let suggestions = docu.iter().try_fold::<SuggestionSet, _, Result<_>>(
+            SuggestionSet::new(),
+            |mut acc, (origin, chunks)| {
+                for chunk in chunks {
+                    let mut new_lines = chunk
+                        .as_str()
+                        .split("\n\n")
+                        .collect::<Vec<&str>>()
+                        .iter()
+                        .map(|s| s.replace("\n", "") )
+                        .fold::<Vec<String>, _>(Vec::new(), |mut acc, comment| {
+                            let mut new_comment = wrapper
+                                .wrap_iter(comment.trim())
+                                .map(|b| b.into_owned()).collect();
+                            acc.append(&mut new_comment);
+                            acc.push("".into());
+                            acc
+                        });
+                    // remove last newline
+                    let _ = new_lines.pop();
+                    // @todo find proper span and range
+                    let range = 0..chunk.as_str().len();
+                    let span = Span { start: LineColumn { line: 0, column: 0}, end: LineColumn { line: 1, column: 5}};
+                    acc.add(
+                        origin.clone(),
+                        Suggestion {
+                            detector: Detector::Wrapper,
+                            range,
+                            span,
+                            origin: origin.clone(),
+                            replacements: vec!["".into()],
+                            chunk,
+                            description: Some("Rewrapped".to_owned()),
+                        },
+                    )
+                }
+                Ok(acc)
+            },
+        )?;
+
+        Ok(suggestions)
     }
 }
 
@@ -63,7 +105,8 @@ mod tests {
             stream,
         ));
 
-        Wrap::rewrap(d, None).expect("failed");
+        let suggestions = Wrapper::check(&d, &WrapConfig::default()).expect("failed");
+        dbg!(suggestions);
 
         assert!(false);
     }

--- a/src/wrap/mod.rs
+++ b/src/wrap/mod.rs
@@ -1,0 +1,86 @@
+//! Wrap
+//!
+//! Re-wrap doc comments for prettier styling in code
+
+use anyhow::Result;
+use log::info;
+use indexmap::IndexMap;
+use std::ops::Range;
+use crate::Span;
+
+use crate::Documentation;
+
+/// Parameters for wrapping doc comments
+#[derive(Debug)]
+pub struct WrapConfig {
+    /// Hard limit for absolute length of lines
+    max_line_length: usize,
+}
+
+impl Default for WrapConfig {
+    fn default() -> Self {
+        WrapConfig { max_line_length: 70 }
+    }
+}
+
+#[derive(Debug)]
+pub struct Wrap {
+    doc: Documentation,
+    config: WrapConfig,
+}
+
+impl Wrap {
+    pub fn new(doc: Documentation, config: Option<WrapConfig>) -> Self {
+        Wrap { doc, config: config.unwrap_or_default() }
+    }
+
+    pub fn rewrap(self) -> Result<()> {
+        // loop through files
+        for (origin, chunks) in self.doc.iter() {
+            for chunk in chunks {
+                // check length
+                let oob = chunk.iter().filter(|(r, s)| {
+                    s.end.column > self.config.max_line_length
+                }).map(|(r, s)| {
+                    for range in crate::checker::tokenize(chunk.as_str()) {
+                        // get all words with span > max_line_length
+                    }
+
+                });
+
+                log::warn!("oob {:?}", oob);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::documentation::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn rewrap() {
+        let _ = env_logger::builder()
+            .filter(None, log::LevelFilter::Trace)
+            .is_test(true)
+            .try_init();
+
+        const TEST: &str = include_str!("../../demo/src/lib.rs");
+
+        let stream =
+            syn::parse_str::<proc_macro2::TokenStream>(TEST).expect("Must parse just fine");
+
+        let d = Documentation::from((
+            ContentOrigin::RustSourceFile(PathBuf::from("dummy/dummy.rs")),
+            stream,
+        ));
+
+        let wrapper = Wrap::new(d, None);
+        wrapper.rewrap().expect("failed");
+
+        assert!(false);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->

**Feature**


closes #39  .

## Changes proposed by this PR:

Add a another `Checker` for wrapping using the `textwrap` crate. I'm not sure if the Checker trait is a good way to do this, but I thought it wouldn't bloat the API since we could reuse a lot of could for applying the new re-wrapped comments. I'm not quite sure about the resulting 'multi-line' comments, though. You think thats possible that way or do we need multi-line support first?
