### PR TITLE
cmark files and multiline fragments

### DIFF
--- a/.concourse.yml
+++ b/.concourse.yml
@@ -289,9 +289,9 @@ jobs:
               export CARGO_HOME="$(pwd)/../cargo"
               sudo chown $(whoami): -Rf ${CARGO_HOME} .
               cargo +stable run -- --version
-              cargo +stable run -- spellcheck demo/Cargo.toml || echo "$?"
-              cargo +stable run -- spellcheck demo/src/main.rs || echo "$?"
-              cargo +stable run -- spellcheck demo/ || echo "$?"
+              cargo +stable run -- spellcheck demo/Cargo.toml
+              cargo +stable run -- spellcheck demo/src/main.rs
+              cargo +stable run -- spellcheck demo/
             dir: git-repo
           caches:
           - path: cargo

--- a/src/action/bandaid.rs
+++ b/src/action/bandaid.rs
@@ -110,38 +110,43 @@ pub(crate) mod tests {
             bail!("Column range would be negative, bail")
         }
         let mut s = String::with_capacity(256);
-        source.read_to_string(&mut s).expect("Must read successfully");
-        let cursor = LineColumn {line: 1, column: 0};
-        let extraction = s.chars().enumerate().scan(cursor, |cursor, (idx, c)| {
-            let x = (idx, c, cursor.clone());
-            match c {
-                '\n' => {
-                    cursor.line += 1;
-                    cursor.column = 0;
+        source
+            .read_to_string(&mut s)
+            .expect("Must read successfully");
+        let cursor = LineColumn { line: 1, column: 0 };
+        let extraction = s
+            .chars()
+            .enumerate()
+            .scan(cursor, |cursor, (idx, c)| {
+                let x = (idx, c, cursor.clone());
+                match c {
+                    '\n' => {
+                        cursor.line += 1;
+                        cursor.column = 0;
+                    }
+                    _ => cursor.column += 1,
                 }
-                _ => cursor.column += 1,
-            }
-            Some(x)
-        })
-        .filter_map(|(idx, c, cursor)| {
-            if cursor.line < span.start.line {
-                return None;
-            }
-            if cursor.line > span.end.line {
-                return None;
-            }
-            // bounding lines
-            if cursor.line == span.start.line && cursor.column < span.start.column {
-                return None;
-            }
-            if cursor.line == span.end.line && cursor.column > span.end.column {
-                return None;
-            }
-            Some(c)
-        }).collect::<String>();
+                Some(x)
+            })
+            .filter_map(|(idx, c, cursor)| {
+                if cursor.line < span.start.line {
+                    return None;
+                }
+                if cursor.line > span.end.line {
+                    return None;
+                }
+                // bounding lines
+                if cursor.line == span.start.line && cursor.column < span.start.column {
+                    return None;
+                }
+                if cursor.line == span.end.line && cursor.column > span.end.column {
+                    return None;
+                }
+                Some(c)
+            })
+            .collect::<String>();
         // log::trace!("Loading {:?} from line >{}<", &range, &line);
         Ok(extraction)
-
     }
 
     #[test]

--- a/src/action/bandaid.rs
+++ b/src/action/bandaid.rs
@@ -1,6 +1,6 @@
 use crate::span::Span;
 use crate::suggestion::Suggestion;
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, bail, Error, Result};
 use log::trace;
 use std::convert::TryFrom;
 
@@ -45,7 +45,7 @@ impl<'s> TryFrom<(&Suggestion<'s>, usize)> for BandAid {
         if let Some(replacement) = suggestion.replacements.iter().nth(pick_idx) {
             Ok(Self::new(replacement.as_str(), &suggestion.span))
         } else {
-            Err(anyhow!("Does not contain any replacements"))
+            bail!("Does not contain any replacements")
         }
     }
 }

--- a/src/action/bandaid.rs
+++ b/src/action/bandaid.rs
@@ -114,24 +114,45 @@ pub(crate) mod tests {
             .lines()
             .skip(span.start.line - 1)
             .filter_map(|line| line.ok())
-            .take(span.end.line - span.start.line + 1).collect();
+            .take(span.end.line - span.start.line + 1)
+            .collect();
 
-        assert!(multiline.len() > 0);
+        assert!(dbg!(&multiline).len() > 0);
 
-        match  multiline.len() {
-            0 => unreachable!("Must never be one"),
-            1 => Ok(multiline[0].chars().take(span.end.column).skip(span.start.column.saturating_sub(1)).collect::<String>()),
-            _ => {
-                let first = multiline.first().unwrap().chars().skip(span.start.column.saturating_sub(1)).collect::<String>();
-                let last = multiline.last().unwrap().chars().take(span.end.column).collect::<String>();
-                multiline.first_mut().map(move |val| *val = dbg!(first) ).unwrap();
-                multiline.last_mut().map(move |val| *val = dbg!(last) ).unwrap();
+        match multiline.len() {
+            0 => unreachable!("Must never be nil"),
+            1 => Ok(multiline[0]
+                .chars()
+                .take(span.end.column + 1)
+                .skip(span.start.column)
+                .collect::<String>()),
+            x if x > 1 => {
+                let first = multiline
+                    .first()
+                    .unwrap()
+                    .chars()
+                    .skip(span.start.column)
+                    .collect::<String>();
+                let last = multiline
+                    .last()
+                    .unwrap()
+                    .chars()
+                    .take(span.end.column + 1)
+                    .collect::<String>();
+                multiline
+                    .first_mut()
+                    .map(move |val| *val = dbg!(first))
+                    .unwrap();
+                multiline
+                    .last_mut()
+                    .map(move |val| *val = dbg!(last))
+                    .unwrap();
                 Ok(dbg!(multiline).join("\n"))
             }
+            _ => unreachable!("should not be negative or an invalid number"),
         }
 
         // log::trace!("Loading {:?} from line >{}<", &range, &line);
-
     }
 
     #[test]

--- a/src/action/bandaid.rs
+++ b/src/action/bandaid.rs
@@ -1,6 +1,6 @@
 use crate::span::Span;
 use crate::suggestion::Suggestion;
-use anyhow::{anyhow, bail, Error, Result};
+use anyhow::{bail, Error, Result};
 use log::trace;
 use std::convert::TryFrom;
 
@@ -67,7 +67,7 @@ impl From<(String, Span)> for BandAid {
 pub(crate) mod tests {
     use super::*;
     use crate::span::Span;
-    use anyhow::bail;
+    use anyhow::anyhow;
     use proc_macro2::LineColumn;
     use std::io::Read;
     use std::path::Path;

--- a/src/checker/dummy.rs
+++ b/src/checker/dummy.rs
@@ -44,7 +44,7 @@ impl Checker for DummyChecker {
                             chunk,
                             description: None,
                         };
-                        acc.add(origin.clone(), dbg!(suggestion));
+                        acc.add(origin.clone(), suggestion);
                     }
                 }
                 Ok(acc)

--- a/src/checker/hunspell.rs
+++ b/src/checker/hunspell.rs
@@ -89,19 +89,14 @@ impl Checker for HunspellChecker {
         for extra_dic in config.extra_dictonaries().iter() {
             trace!("Adding extra hunspell dictionary {}", extra_dic.display());
             if !extra_dic.is_file() {
-                bail!(
-                    "Extra dictionary {} is not a file",
-                    extra_dic.display()
-                )
+                bail!("Extra dictionary {} is not a file", extra_dic.display())
             }
             if let Some(extra_dic) = extra_dic.to_str() {
                 if !hunspell.add_dictionary(extra_dic) {
                     bail!("Failed to add additional dict to hunspell")
                 }
             } else {
-                bail!(
-                    "Failed to convert one of the extra dictionaries to a str"
-                )
+                bail!("Failed to convert one of the extra dictionaries to a str")
             }
         }
 

--- a/src/checker/hunspell.rs
+++ b/src/checker/hunspell.rs
@@ -12,7 +12,7 @@ use log::{debug, trace};
 
 use hunspell_rs::Hunspell;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 
 pub struct HunspellChecker;
 
@@ -89,19 +89,19 @@ impl Checker for HunspellChecker {
         for extra_dic in config.extra_dictonaries().iter() {
             trace!("Adding extra hunspell dictionary {}", extra_dic.display());
             if !extra_dic.is_file() {
-                return Err(anyhow!(
+                bail!(
                     "Extra dictionary {} is not a file",
                     extra_dic.display()
-                ));
+                )
             }
             if let Some(extra_dic) = extra_dic.to_str() {
                 if !hunspell.add_dictionary(extra_dic) {
-                    return Err(anyhow!("Failed to add additional dict to hunspell"));
+                    bail!("Failed to add additional dict to hunspell")
                 }
             } else {
-                return Err(anyhow!(
+                bail!(
                     "Failed to convert one of the extra dictionaries to a str"
-                ));
+                )
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,9 +133,7 @@ impl Config {
                     .join("config.toml"),
             )
         } else {
-            bail!(
-                "No idea where your config directory is located. XDG compliance would be nice."
-            )
+            bail!("No idea where your config directory is located. XDG compliance would be nice.")
         }
     }
 
@@ -185,9 +183,7 @@ impl Config {
         {
             Ok(base.config_dir().join("config.toml"))
         } else {
-            bail!(
-                "No idea where your config directory is located. `$HOME` must be set."
-            )
+            bail!("No idea where your config directory is located. `$HOME` must be set.")
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@
 //! location by default. Default. Default default default.
 
 use crate::suggestion::Detector;
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, bail, Error, Result};
 use log::trace;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
@@ -133,9 +133,9 @@ impl Config {
                     .join("config.toml"),
             )
         } else {
-            Err(anyhow!(
+            bail!(
                 "No idea where your config directory is located. XDG compliance would be nice."
-            ))
+            )
         }
     }
 
@@ -185,9 +185,9 @@ impl Config {
         {
             Ok(base.config_dir().join("config.toml"))
         } else {
-            Err(anyhow!(
+            bail!(
                 "No idea where your config directory is located. `$HOME` must be set."
-            ))
+            )
         }
     }
 

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -178,7 +178,7 @@ impl CheckableChunk {
                         sub_fragment_range.len()
                     );
                 }
-                log::warn!(
+                log::trace!(
                     ">> sub_fragment range={:?} span={:?} => {}",
                     &sub_fragment_range,
                     &sub_fragment_span,

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -159,7 +159,6 @@ impl CheckableChunk {
                     }
                     Some(x)
                 }) {
-
                     trace!("char[{}]: {}", idx, c);
                     if idx == shift {
                         sub_fragment_span.start = cursor;

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -377,28 +377,30 @@ mod test {
         let _ = env_logger::builder().is_test(true).try_init();
 
         const SOURCE: &'static str = fluff_up!(["xyz", "second", "third", "Converts a span to a range, where `self` is converted to a range reltive to the",
-        "passed span `scope`."] @ "    "
+        "passed span `scope`."] @ "       "
    );
         let set = gen_literal_set(SOURCE);
         let chunk = dbg!(CheckableChunk::from_literalset(set));
+        const SPACES: usize = 7;
+        const TRIPLE_SLASH_SPACE: usize = 4;
         const CHUNK_RANGES: &[Range] =
             &[1..4, (4 + 1 + 1 + 6 + 1 + 1)..(4 + 1 + 1 + 6 + 1 + 1 + 5)];
         const EXPECTED_SPANS: &[Span] = &[
             Span {
-                start: LineColumn { line: 1, column: 4 },
-                end: LineColumn { line: 1, column: 6 },
+                start: LineColumn { line: 1, column: SPACES + TRIPLE_SLASH_SPACE + 0 },
+                end: LineColumn { line: 1, column: SPACES + TRIPLE_SLASH_SPACE + 2 },
             },
             Span {
-                start: LineColumn { line: 3, column: 4 },
-                end: LineColumn { line: 3, column: 8 },
+                start: LineColumn { line: 3, column: SPACES + TRIPLE_SLASH_SPACE + 0 },
+                end: LineColumn { line: 3, column: SPACES + TRIPLE_SLASH_SPACE + 4 },
             },
             Span {
-                start: LineColumn { line: 4, column: 4 },
-                end: LineColumn { line: 4, column: 79+4-1  },
+                start: LineColumn { line: 4, column: SPACES + TRIPLE_SLASH_SPACE + 0 },
+                end: LineColumn { line: 4, column: SPACES + TRIPLE_SLASH_SPACE + 78  },
             },
             Span {
-                start: LineColumn { line: 5, column: 4 },
-                end: LineColumn { line: 5, column: 20+4-1  },
+                start: LineColumn { line: 5, column: SPACES + TRIPLE_SLASH_SPACE + 0 },
+                end: LineColumn { line: 5, column: SPACES + TRIPLE_SLASH_SPACE + 19 },
             },
         ];
         const EXPECTED_STR: &[&'static str] = &["xyz", "third", "Converts a span to a range, where `self` is converted to a range reltive to the",

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -124,7 +124,6 @@ impl CheckableChunk {
                 let sub_fragment_range = std::cmp::max(fragment_range.start, range.start)
                     ..std::cmp::min(fragment_range.end, range.end);
 
-
                 trace!(
                     ">> fragment: span: {:?} => range: {:?} | sub: {:?} -> sub_fragment: {:?}",
                     &fragment_span,
@@ -133,9 +132,12 @@ impl CheckableChunk {
                     &sub_fragment_range,
                 );
 
-                log::trace!("[f]display;\n>{}<", ChunkDisplay::try_from((self, fragment_range.clone())).expect("must be convertable"));
+                log::trace!(
+                    "[f]display;\n>{}<",
+                    ChunkDisplay::try_from((self, fragment_range.clone()))
+                        .expect("must be convertable")
+                );
                 log::trace!("[f]content;\n>{}<", &self.as_str()[fragment_range.clone()]);
-
 
                 if sub_fragment_range.len() == 0 {
                     log::debug!("sub fragment is zero, dropping!");
@@ -377,8 +379,8 @@ mod test {
         let _ = env_logger::builder().is_test(true).try_init();
 
         const SOURCE: &'static str = fluff_up!(["xyz", "second", "third", "Converts a span to a range, where `self` is converted to a range reltive to the",
-        "passed span `scope`."] @ "       "
-   );
+             "passed span `scope`."] @ "       "
+        );
         let set = gen_literal_set(SOURCE);
         let chunk = dbg!(CheckableChunk::from_literalset(set));
         const SPACES: usize = 7;
@@ -387,24 +389,52 @@ mod test {
             &[1..4, (4 + 1 + 1 + 6 + 1 + 1)..(4 + 1 + 1 + 6 + 1 + 1 + 5)];
         const EXPECTED_SPANS: &[Span] = &[
             Span {
-                start: LineColumn { line: 1, column: SPACES + TRIPLE_SLASH_SPACE + 0 },
-                end: LineColumn { line: 1, column: SPACES + TRIPLE_SLASH_SPACE + 2 },
+                start: LineColumn {
+                    line: 1,
+                    column: SPACES + TRIPLE_SLASH_SPACE + 0,
+                },
+                end: LineColumn {
+                    line: 1,
+                    column: SPACES + TRIPLE_SLASH_SPACE + 2,
+                },
             },
             Span {
-                start: LineColumn { line: 3, column: SPACES + TRIPLE_SLASH_SPACE + 0 },
-                end: LineColumn { line: 3, column: SPACES + TRIPLE_SLASH_SPACE + 4 },
+                start: LineColumn {
+                    line: 3,
+                    column: SPACES + TRIPLE_SLASH_SPACE + 0,
+                },
+                end: LineColumn {
+                    line: 3,
+                    column: SPACES + TRIPLE_SLASH_SPACE + 4,
+                },
             },
             Span {
-                start: LineColumn { line: 4, column: SPACES + TRIPLE_SLASH_SPACE + 0 },
-                end: LineColumn { line: 4, column: SPACES + TRIPLE_SLASH_SPACE + 78  },
+                start: LineColumn {
+                    line: 4,
+                    column: SPACES + TRIPLE_SLASH_SPACE + 0,
+                },
+                end: LineColumn {
+                    line: 4,
+                    column: SPACES + TRIPLE_SLASH_SPACE + 78,
+                },
             },
             Span {
-                start: LineColumn { line: 5, column: SPACES + TRIPLE_SLASH_SPACE + 0 },
-                end: LineColumn { line: 5, column: SPACES + TRIPLE_SLASH_SPACE + 19 },
+                start: LineColumn {
+                    line: 5,
+                    column: SPACES + TRIPLE_SLASH_SPACE + 0,
+                },
+                end: LineColumn {
+                    line: 5,
+                    column: SPACES + TRIPLE_SLASH_SPACE + 19,
+                },
             },
         ];
-        const EXPECTED_STR: &[&'static str] = &["xyz", "third", "Converts a span to a range, where `self` is converted to a range reltive to the",
-        "passed span `scope`."];
+        const EXPECTED_STR: &[&'static str] = &[
+            "xyz",
+            "third",
+            "Converts a span to a range, where `self` is converted to a range reltive to the",
+            "passed span `scope`.",
+        ];
 
         for (query_range, expected_span, expected_str) in itertools::cons_tuples(
             CHUNK_RANGES

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -169,8 +169,6 @@ impl CheckableChunk {
                     }
                 }
 
-                // let _ = dbg!(&sub_fragment_span);
-                // let _ = dbg!(&sub_fragment_range);
                 if sub_fragment_span.start.line == sub_fragment_span.end.line {
                     assert!(sub_fragment_span.start.column <= sub_fragment_span.end.column);
                     assert_eq!(

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -165,8 +165,6 @@ impl CheckableChunk {
                     trace!("char[{}]: {}", idx, c);
                     if idx == shift {
                         sub_fragment_span.start = cursor;
-                        sub_fragment_span.end = cursor; // assure this is valid
-                        continue;
                     }
                     sub_fragment_span.end = cursor; // always set, even if we never reach the end of fragment
                     if idx >= (sub_fragment_range.len() + shift - 1) {

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -108,7 +108,6 @@ impl CheckableChunk {
         );
 
         let Range { start, end } = range;
-        let mut active = false;
         self.source_mapping
             .iter()
             .skip_while(|(fragment_range, _span)| fragment_range.end <= start)
@@ -152,7 +151,6 @@ impl CheckableChunk {
                 for (idx, c, cursor) in s.chars().enumerate().scan(state, |state, (idx, c)| {
                     let x: (usize, char, LineColumn) = (idx, c, state.clone());
                     match c {
-                        '\r' => {} // @todo assert the following char is a \n
                         '\n' => {
                             state.line += 1;
                             state.column = 0;
@@ -172,13 +170,13 @@ impl CheckableChunk {
                     }
                 }
 
-                let _ = dbg!(&sub_fragment_span);
-                let _ = dbg!(&sub_fragment_range);
+                // let _ = dbg!(&sub_fragment_span);
+                // let _ = dbg!(&sub_fragment_range);
                 if sub_fragment_span.start.line == sub_fragment_span.end.line {
                     assert!(sub_fragment_span.start.column <= sub_fragment_span.end.column);
                     assert_eq!(
-                        dbg!(sub_fragment_span.end.column + 1 - sub_fragment_span.start.column),
-                        dbg!(&sub_fragment_range).len()
+                        sub_fragment_span.end.column + 1 - sub_fragment_span.start.column,
+                        sub_fragment_range.len()
                     );
                 }
                 log::warn!(
@@ -203,6 +201,10 @@ impl CheckableChunk {
 
     pub fn iter(&self) -> indexmap::map::Iter<Range, Span> {
         self.source_mapping.iter()
+    }
+
+    pub fn fragment_count(&self) -> usize {
+        self.source_mapping.len()
     }
 }
 

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -143,12 +143,9 @@ impl CheckableChunk {
                     log::debug!("sub fragment is zero, dropping!");
                     return None;
                 }
-                if fragment_span.start.line == fragment_span.end.line {
-                    assert!(fragment_span.start.column <= fragment_span.end.column);
-                    assert_eq!(
-                        fragment_span.end.column + 1 - fragment_span.start.column,
-                        fragment_range.len()
-                    );
+
+                if let Some(span_len) = fragment_span.one_line_len() {
+                    assert_eq!(span_len, fragment_range.len());
                 }
                 // take the full fragment string, we need to count newlines before and after
                 let s = &self.as_str()[fragment_range.clone()];
@@ -177,12 +174,8 @@ impl CheckableChunk {
                     }
                 }
 
-                if sub_fragment_span.start.line == sub_fragment_span.end.line {
-                    assert!(sub_fragment_span.start.column <= sub_fragment_span.end.column);
-                    assert_eq!(
-                        sub_fragment_span.end.column + 1 - sub_fragment_span.start.column,
-                        sub_fragment_range.len()
-                    );
+                if let Some(sub_fragment_span_len) = sub_fragment_span.one_line_len() {
+                    assert_eq!(sub_fragment_span_len, sub_fragment_range.len());
                 }
                 log::trace!(
                     ">> sub_fragment range={:?} span={:?} => {}",

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -137,12 +137,11 @@ impl CheckableChunk {
                     return None;
                 }
                 if fragment_span.start.line == fragment_span.end.line {
+                    assert!(fragment_span.start.column <= fragment_span.end.column);
                     assert_eq!(
-                        fragment_span.end.column - fragment_span.start.column + 1,
+                        fragment_span.end.column + 1 - fragment_span.start.column,
                         fragment_range.len()
                     );
-                } else {
-                    assert!(fragment_span.start.column <= fragment_span.end.column);
                 }
                 // take the full fragment string, we need to count newlines before and after
                 let s = &self.as_str()[fragment_range.clone()];
@@ -178,12 +177,11 @@ impl CheckableChunk {
                 let _ = dbg!(&sub_fragment_span);
                 let _ = dbg!(&sub_fragment_range);
                 if sub_fragment_span.start.line == sub_fragment_span.end.line {
+                    assert!(sub_fragment_span.start.column <= sub_fragment_span.end.column);
                     assert_eq!(
-                        dbg!(sub_fragment_span.end.column - sub_fragment_span.start.column + 1),
+                        dbg!(sub_fragment_span.end.column + 1 - sub_fragment_span.start.column),
                         dbg!(&sub_fragment_range).len()
                     );
-                } else {
-                    assert!(sub_fragment_span.start.column <= sub_fragment_span.end.column);
                 }
                 log::warn!(
                     ">> sub_fragment range={:?} span={:?} => {}",
@@ -269,8 +267,6 @@ where
     type Error = Error;
     fn try_from(tuple: (R, Span)) -> Result<Self> {
         let chunk = tuple.0.into();
-        let _first = chunk.source_mapping.iter().next().unwrap().1; // @todo
-        let _last = chunk.source_mapping.iter().rev().next().unwrap().1; // @todo
         let span = tuple.1;
         let range = span.to_content_range(chunk)?;
         Ok(Self(chunk, range))

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -1,5 +1,5 @@
 use crate::{Range, Span};
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 
 use regex::Regex;
 use std::convert::TryFrom;
@@ -69,20 +69,20 @@ impl TryFrom<proc_macro2::Literal> for TrimmedLiteral {
             if let Some(prefix) = captures.get(1) {
                 prefix.as_str().len()
             } else {
-                return Err(anyhow!("Unknown prefix of literal"));
+                bail!("Unknown prefix of literal");
             }
         } else {
-            return Err(anyhow!("Missing prefix of literal: {}", rendered.as_str()));
+            bail!("Missing prefix of literal: {}", rendered.as_str());
         };
         let post = if let Some(captures) = SUFFIX_ERASER.captures(rendered.as_str()) {
             // capture indices are 1 based, 0 is the full string
             if let Some(suffix) = captures.get(captures.len() - 1) {
                 suffix.as_str().len()
             } else {
-                return Err(anyhow!("Unknown suffix of literal"));
+                bail!("Unknown suffix of literal");
             }
         } else {
-            return Err(anyhow!("Missing suffix of literal: {}", rendered.as_str()));
+            bail!("Missing suffix of literal: {}", rendered.as_str());
         };
 
         let (len, pre, post) = match rendered.len() {

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -262,8 +262,8 @@ impl<'a> fmt::Display for TrimmedLiteralDisplay<'a> {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::LineColumn;
     use crate::action::bandaid::tests::load_span_from;
+    use crate::LineColumn;
 
     pub(crate) fn annotated_literals(source: &str) -> Vec<TrimmedLiteral> {
         let stream =
@@ -296,7 +296,7 @@ pub(crate) mod tests {
     const SUFFIX_RAW_LEN: usize = 2;
     const GAENSEFUESSCHEN: usize = 1;
 
-    #[derive(Clone,Debug)]
+    #[derive(Clone, Debug)]
     struct Triplet {
         /// source content
         source: &'static str,
@@ -340,7 +340,6 @@ struct One;
                 },
             },
         },
-
         // 1
         Triplet {
             source: r##"
@@ -471,9 +470,11 @@ lines
         },
     ];
 
-
     fn comment_variant_span_range_validation(index: usize) {
-        let _ = env_logger::builder().filter(None, log::LevelFilter::Trace).is_test(true).try_init();
+        let _ = env_logger::builder()
+            .filter(None, log::LevelFilter::Trace)
+            .is_test(true)
+            .try_init();
 
         let triplet = TEST_DATA[index].clone();
         let literals = annotated_literals(triplet.source);
@@ -487,13 +488,13 @@ lines
         assert_eq!(literal.as_str(), triplet.trimmed);
 
         // just for better visual errors
-        let excerpt = load_span_from(triplet.source.as_bytes(), literal.span());
-        let expected_excerpt = load_span_from(triplet.source.as_bytes(), triplet.trimmed_span);
+        let excerpt = load_span_from(triplet.source.as_bytes(), literal.span()).unwrap();
+        let expected_excerpt =
+            load_span_from(triplet.source.as_bytes(), triplet.trimmed_span).unwrap();
         assert_eq!(excerpt, expected_excerpt);
 
         assert_eq!(literal.span(), triplet.trimmed_span);
     }
-
 
     #[test]
     fn raw_variant_0() {

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -1,5 +1,5 @@
 use crate::{Range, Span};
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 
 use regex::Regex;
 use std::convert::TryFrom;
@@ -87,7 +87,7 @@ impl TryFrom<proc_macro2::Literal> for TrimmedLiteral {
 
         let (len, pre, post) = match rendered.len() {
             len if len >= pre + post => (len - pre - post, pre, post),
-            _len => return Err(anyhow!("Prefix and suffix overlap, which is impossible")),
+            _len => bail!("Prefix and suffix overlap, which is impossible"),
         };
 
         let mut span = Span::from(literal.span());

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -129,7 +129,7 @@ impl TryFrom<proc_macro2::Literal> for TrimmedLiteral {
                 log::trace!(target: "quirks", "Dealing with #[doc=r####\"...\"#### style comment");
                 span.start.column += pre;
                 span.end.column -= post;
-                if let Some(span_len) = span.one_line_len() {
+                if let Some(_span_len) = span.one_line_len() {
                     span.end.column = span.end.column.saturating_sub(1);
                 }
             }

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -94,8 +94,6 @@ impl TryFrom<proc_macro2::Literal> for TrimmedLiteral {
 
         // check if it is a `///` comment, for which the literal
         // span needs to be adjusted, since it would include the `///`
-        // @todo find a better way, potentially doing this when
-        // creating a `TrimmedLiteral` and storing this on construction
         if pre == 1 && span.start.column == 0 {
             span.start.column += 2;
         }

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -143,6 +143,8 @@ impl TrimmedLiteral {
         self.span.clone()
     }
 
+    /// Display helper, mostly used for debug investigations
+    #[allow(unused)]
     pub(crate) fn display(&self, highlight: Range) -> TrimmedLiteralDisplay {
         TrimmedLiteralDisplay::from((self, highlight))
     }

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -111,10 +111,10 @@ pub(crate) mod tests {
     #[macro_export]
     macro_rules! feather_up {
         ([ $( $line:literal ),+ $(,)?]) => {
-            concat!("", r##"#[doc=r#""## $(, $line, "\n")+, r##""#]"##, "\n", "struct Mechanical;")
+            feather_up!( $( $line ),+ )
         };
-        ($( $line:literal ),+ $(,)?) => {
-            feather_up!([$( $line ),+])
+        ($first:literal $(, $( $line:literal ),+ )? $(,)? ) => {
+            concat!("", r##"#[doc=r#""##, $first $( $(, "\n", $line )+ )?, r##""#]"##, "\n", "struct Mechanical;")
         };
     }
 
@@ -149,8 +149,11 @@ struct Fluff;"#;
     pub(crate) fn gen_literal_set(source: &str) -> LiteralSet {
         let literals = dbg!(annotated_literals(dbg!(source)));
 
-        let mut cls = LiteralSet::default();
-        for literal in literals {
+        let mut iter = dbg!(literals).into_iter();
+        let literal = iter.next().expect("Must have at least one item in laterals");
+        let mut cls = LiteralSet::from(literal);
+
+        for literal in iter {
             assert!(cls.add_adjacent(literal).is_ok());
         }
         dbg!(cls)

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -109,12 +109,12 @@ pub(crate) mod tests {
     use super::*;
 
     #[macro_export]
-    macro_rules! feather_up {
+    macro_rules! chyrp_up {
         ([ $( $line:literal ),+ $(,)?]) => {
-            feather_up!( $( $line ),+ )
+            chyrp_up!( $( $line ),+ )
         };
         ($first:literal $(, $( $line:literal ),+ )? $(,)? ) => {
-            concat!("", r##"#[doc=r#""##, $first $( $(, "\n", $line )+ )?, r##""#]"##, "\n", "struct Mechanical;")
+            concat!("", r##"#[doc=r#""##, $first $( $(, "\n", $line )+ )?, r##""#]"##, "\n", "struct ChyrpChyrp;")
         };
     }
 

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -1,5 +1,5 @@
 pub use super::{TrimmedLiteral, TrimmedLiteralDisplay};
-use crate::{CheckableChunk, Range, Span};
+use crate::{CheckableChunk, Range};
 /// A set of consecutive literals.
 ///
 /// Provides means to render them as a code block

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -110,11 +110,11 @@ pub(crate) mod tests {
 
     #[macro_export]
     macro_rules! chyrp_up {
-        ([ $( $line:literal ),+ $(,)?]) => {
-            chyrp_up!( $( $line ),+ )
+        ([ $( $line:literal ),+ $(,)? ] $(@ $prefix:literal)? ) => {
+            chyrp_up!( $( $line ),+ $(@ $prefix)? )
         };
-        ($first:literal $(, $( $line:literal ),+ )? $(,)? ) => {
-            concat!("", r##"#[doc=r#""##, $first $( $(, "\n", $line )+ )?, r##""#]"##, "\n", "struct ChyrpChyrp;")
+        ($first:literal $(, $( $line:literal ),+ )? $(,)? $(@ $prefix:literal)? ) => {
+            concat!($( $prefix ,)? r##"#[doc=r#""##, $first $( $(, "\n", $line )+ )?, r##""#]"##, "\n", "struct ChyrpChyrp;")
         };
     }
 

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -64,14 +64,15 @@ impl LiteralSet {
                 start = cursor;
                 cursor += literal.len();
                 end = cursor;
-                // @todo check if the `Span` conversion here is done correctly
-                let span = Span::from(literal);
+
+                let span = literal.span();
                 let range = Range { start, end };
-                // if range.len() > 0 {
+
+                if let Some(span_len) = span.one_line_len() {
+                    assert_eq!(range.len(), span_len);
+                }
+                // keep zero length values too, to guarantee continuity
                 source_mapping.insert(range, span);
-                // } else {
-                // log::debug!("Skipping literal >{}< of len {} with mapping {:?} -> {:?}", literal.as_str(), literal.as_str().len(), range, span);
-                // }
                 content.push_str(literal.as_str());
                 // the newline is _not_ covered by a span, after all it's inserted by us!
                 next = it.next();

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -150,7 +150,9 @@ struct Fluff;"#;
         let literals = dbg!(annotated_literals(dbg!(source)));
 
         let mut iter = dbg!(literals).into_iter();
-        let literal = iter.next().expect("Must have at least one item in laterals");
+        let literal = iter
+            .next()
+            .expect("Must have at least one item in laterals");
         let mut cls = LiteralSet::from(literal);
 
         for literal in iter {

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -120,13 +120,17 @@ pub(crate) mod tests {
 
     #[macro_export]
     macro_rules! fluff_up {
-        ([ $( $line:literal ),+ $(,)?]) => {
-            concat!("" $(, "/// ", $line, "\n")+ , "struct Fluff;")
+        ([ $( $line:literal ),+ $(,)?] $( @ $prefix:literal)?) => {
+            fluff_up!($( $line ),+ $(@ $prefix)?)
         };
-        ($( $line:literal ),+ $(,)?) => {
-            fluff_up!([$( $line ),+])
+        ($($line:literal ),+ $(,)? ) => {
+            fluff_up!($( $line ),+ @ "    ")
+        };
+        ($($line:literal ),+ $(,)? @ $prefix:literal ) => {
+            concat!("" $(, $prefix, "/// ", $line, "\n")+ , "struct Fluff;")
         };
     }
+
 
     #[test]
     fn fluff_one() {

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -131,7 +131,6 @@ pub(crate) mod tests {
         };
     }
 
-
     #[test]
     fn fluff_one() {
         const TEST: &'static str = fluff_up!(["a"]);

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -251,8 +251,8 @@ struct Vikings;
                 end: range.end + START,
             };
 
-            assert_eq!(&TEST[range_for_raw_str.clone()], &chunk.as_str()[range]);
-            assert_eq!(&TEST[range_for_raw_str], $expected);
+            assert_eq!(&TEST[range_for_raw_str.clone()], &chunk.as_str()[range], "Testing range extract vs stringified chunk for integrity");
+            assert_eq!(&TEST[range_for_raw_str], $expected, "Testing range extract vs expected");
         };
     }
 

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -109,6 +109,16 @@ pub(crate) mod tests {
     use super::*;
 
     #[macro_export]
+    macro_rules! feather_up {
+        ([ $( $line:literal ),+ $(,)?]) => {
+            concat!("", r##"#[doc=r#""## $(, $line, "\n")+, r##""#]"##, "\n", "struct Mechanical;")
+        };
+        ($( $line:literal ),+ $(,)?) => {
+            feather_up!([$( $line ),+])
+        };
+    }
+
+    #[macro_export]
     macro_rules! fluff_up {
         ([ $( $line:literal ),+ $(,)?]) => {
             concat!("" $(, "/// ", $line, "\n")+ , "struct Fluff;")

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -124,7 +124,7 @@ pub(crate) mod tests {
             fluff_up!($( $line ),+ $(@ $prefix)?)
         };
         ($($line:literal ),+ $(,)? ) => {
-            fluff_up!($( $line ),+ @ "    ")
+            fluff_up!($( $line ),+ @ "")
         };
         ($($line:literal ),+ $(,)? @ $prefix:literal ) => {
             concat!("" $(, $prefix, "/// ", $line, "\n")+ , "struct Fluff;")

--- a/src/documentation/mod.rs
+++ b/src/documentation/mod.rs
@@ -1,6 +1,16 @@
 //! Representation of multiple documents.
 //!
 //! So to speak documentation of project as whole.
+//!
+//! A `literal` is a token provided by `proc_macro2`, which is then
+//! converted by means of `TrimmedLiteral` using `Cluster`ing
+//! into a `CheckableChunk` (mostly named just `chunk`).
+//!
+//! `CheckableChunk`s can consist of multiple fragments, where
+//! each fragment. Fragments can span multiple lines, yet each fragment
+//! is covering a consecutive `Span` in the origin content.
+//! Each fragment also has a direct mapping to the `CheckableChunk` internal
+//! string representation.
 
 use super::*;
 

--- a/src/documentation/mod.rs
+++ b/src/documentation/mod.rs
@@ -7,7 +7,7 @@
 //! into a `CheckableChunk` (mostly named just `chunk`).
 //!
 //! `CheckableChunk`s can consist of multiple fragments, where
-//! each fragment. Fragments can span multiple lines, yet each fragment
+//! each fragment can span multiple lines, yet each fragment
 //! is covering a consecutive `Span` in the origin content.
 //! Each fragment also has a direct mapping to the `CheckableChunk` internal
 //! string representation.

--- a/src/documentation/mod.rs
+++ b/src/documentation/mod.rs
@@ -200,7 +200,7 @@ mod tests {
                 .iter()
                 .next()
                 .expect("Must contain exactly one item");
-            assert_eq!(dbg!(suggestions).len(), $n);
+            assert_eq!(suggestions.len(), $n);
             suggestion_set
         }};
     }

--- a/src/documentation/mod.rs
+++ b/src/documentation/mod.rs
@@ -299,7 +299,7 @@ Erronbeous bold uetchkp"#;
             let range: Range = suggestion
                 .span
                 .to_content_range(&suggestion.chunk)
-                .expect("Must be a single line");
+                .expect("Must work to derive content range from chunk and span");
 
             log::info!(
                 "Foxxy funkster: {}",

--- a/src/span.rs
+++ b/src/span.rs
@@ -10,7 +10,7 @@ pub use proc_macro2::LineColumn;
 
 use std::hash::{Hash, Hasher};
 
-use anyhow::{anyhow, bail, Error, Result};
+use anyhow::{bail, Error, Result};
 
 use std::convert::TryFrom;
 
@@ -46,10 +46,10 @@ impl Span {
         let scope: Range = scope.try_into()?;
         let me: Range = self.try_into()?;
         if scope.start > me.start {
-            return Err(anyhow!("start of {:?} is not inside of {:?}", me, scope));
+            bail!("start of {:?} is not inside of {:?}", me, scope)
         }
         if scope.end < me.end {
-            return Err(anyhow!("end of {:?} is not inside of {:?}", me, scope));
+            bail!("end of {:?} is not inside of {:?}", me, scope)
         }
         let offset = me.start - scope.start;
         let length = me.end - me.start;
@@ -94,11 +94,11 @@ impl Span {
                 continue;
             }
             if line > self.end.line {
-                bail!("Moved beyond anticipated line");
+                bail!("Moved beyond anticipated line")
             }
 
             if line >= self.end.line && col > self.end.column {
-                bail!("Moved beyond anticipated column and last line");
+                bail!("Moved beyond anticipated column and last line")
             }
             if line == self.start.line && col == self.start.column {
                 start = idx;
@@ -111,11 +111,11 @@ impl Span {
             }
 
             if line > self.end.line {
-                bail!("Moved beyond anticipated line");
+                bail!("Moved beyond anticipated line")
             }
 
             if line >= self.end.line && col > self.end.column {
-                bail!("Moved beyond anticipated column and last line");
+                bail!("Moved beyond anticipated column and last line")
             }
         }
 
@@ -133,7 +133,7 @@ impl Span {
     /// which are used to map.
     pub fn to_content_range(&self, chunk: &CheckableChunk) -> Result<Range> {
         if chunk.fragment_count() == 0 {
-            bail!("Chunk contains 0 fragments");
+            bail!("Chunk contains 0 fragments")
         }
         for (fragment_range, fragment_span) in chunk
             .iter()
@@ -189,11 +189,11 @@ impl TryInto<Range> for &Span {
                 end: self.end.column + 1,
             })
         } else {
-            Err(anyhow!(
+            bail!(
                 "Start and end are not in the same line {} vs {}",
                 self.start.line,
                 self.end.line
-            ))
+            )
         }
     }
 }
@@ -213,11 +213,11 @@ impl TryFrom<(usize, Range)> for Span {
                 },
             })
         } else {
-            Err(anyhow!(
+            bail!(
                 "range must be valid to be converted to a Span {}..{}",
                 original.1.start,
                 original.1.end
-            ))
+            )
         }
     }
 }

--- a/src/span.rs
+++ b/src/span.rs
@@ -65,6 +65,16 @@ impl Span {
         self.end.line <= line && line >= self.start.line
     }
 
+    /// If this one resembles a single line, returns the a `Some(len)` value.
+    /// For multilines this cannot account for the length.
+    pub fn one_line_len(&self) -> Option<usize> {
+        if self.start.line == self.end.line {
+            Some(self.end.column + 1 - self.start.column)
+        } else {
+            None
+        }
+    }
+
     /// extract a `Range` which maps to `self` as
     /// `span` maps to `range`, where `range` is relative to `full_content`
     fn extract_sub_range_from_span(
@@ -121,9 +131,11 @@ impl Span {
 
         let range2 = (offset + start)..(offset + end + 1);
         assert!(range2.len() <= range.len());
-        if span.start.line == span.end.line {
-            assert_eq!(range.len(), span.end.column - span.start.column + 1);
+
+        if let Some(span_len) = span.one_line_len() {
+            assert_eq!(range.len(), span_len);
         }
+
         return Ok(range2);
     }
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -80,11 +80,13 @@ impl Span {
         let state = span.start;
         for (idx, _c, line, col) in s.chars().enumerate().scan(state, |state, (idx, c)| {
             let x = (idx, c, state.line, state.column);
-            if c == '\n' {
-                state.line += 1;
-                state.column = 0;
-            } else {
-                state.column += 1;
+            match c {
+                '\r' => {} // @todo assert the following char is a \n
+                '\n' => {
+                    state.line += 1;
+                    state.column = 0;
+                }
+                _ => { state.column += 1 }
             }
             Some(x)
         }) {

--- a/src/span.rs
+++ b/src/span.rs
@@ -101,7 +101,7 @@ impl Span {
                 let range2 = (offset + start)..(offset + idx + 1);
                 assert!(range2.len() <= range.len());
                 if span.start.line == span.end.line {
-                    assert_eq!(range2.len(), span.end.column - span.end.column + 1);
+                    assert_eq!(range2.len(), span.end.column - span.start.column + 1);
                 }
                 return Ok(range2);
             }

--- a/src/span.rs
+++ b/src/span.rs
@@ -86,7 +86,7 @@ impl Span {
                     state.line += 1;
                     state.column = 0;
                 }
-                _ => { state.column += 1 }
+                _ => state.column += 1,
             }
             Some(x)
         }) {

--- a/src/span.rs
+++ b/src/span.rs
@@ -137,7 +137,7 @@ impl Span {
         }
         for (fragment_range, fragment_span) in chunk
             .iter()
-            // pre-filter to reduce to many calls to `extract_sub_range`
+            // pre-filter to reduce too many calls to `extract_sub_range`
             .filter(|(fragment_range, fragment_span)| {
                 log::trace!(
                     "extracting sub from {:?} ::: {:?} -> {:?}",

--- a/src/span.rs
+++ b/src/span.rs
@@ -139,11 +139,21 @@ impl Span {
             .iter()
             // pre-filter to reduce to many calls to `extract_sub_range`
             .filter(|(fragment_range, fragment_span)| {
-                log::trace!("extracting sub from {:?} ::: {:?} -> {:?}", self, &fragment_range, &fragment_span);
-                self.start.line >= fragment_span.start.line && self.end.line <= fragment_span.end.line
+                log::trace!(
+                    "extracting sub from {:?} ::: {:?} -> {:?}",
+                    self,
+                    &fragment_range,
+                    &fragment_span
+                );
+                self.start.line >= fragment_span.start.line
+                    && self.end.line <= fragment_span.end.line
             })
         {
-            match self.extract_sub_range_from_span(*fragment_span, fragment_range.clone(), chunk.as_str()) {
+            match self.extract_sub_range_from_span(
+                *fragment_span,
+                fragment_range.clone(),
+                chunk.as_str(),
+            ) {
                 Ok(range2) => return Ok(range2),
                 Err(_e) => continue,
             }
@@ -230,7 +240,7 @@ mod tests {
     use crate::action::bandaid::tests::load_span_from;
     use crate::documentation::literalset::tests::gen_literal_set;
     use crate::{chyrp_up, fluff_up};
-    use crate::{Span, LineColumn, Range};
+    use crate::{LineColumn, Range, Span};
 
     #[test]
     fn span_to_range_singleline() {
@@ -276,10 +286,18 @@ mod tests {
         // and as such multiple spans
         const FRAGMENT_STR: &[&'static str] = &["you!!", "Game-Over"];
 
-        for (input, expected, fragment) in
-            itertools::cons_tuples(INPUTS.iter().zip(EXPECTED_RANGE.iter()).zip(FRAGMENT_STR.iter()))
-        {
-            log::trace!(">>>>>>>>>>>>>>>>\ninput: {:?}\nexpected: {:?}\nfragment:>{}<", input, expected, fragment);
+        for (input, expected, fragment) in itertools::cons_tuples(
+            INPUTS
+                .iter()
+                .zip(EXPECTED_RANGE.iter())
+                .zip(FRAGMENT_STR.iter()),
+        ) {
+            log::trace!(
+                ">>>>>>>>>>>>>>>>\ninput: {:?}\nexpected: {:?}\nfragment:>{}<",
+                input,
+                expected,
+                fragment
+            );
             let range = input
                 .to_content_range(&chunk)
                 .expect("Inputs are sane, conversion must work.");
@@ -293,16 +311,11 @@ mod tests {
         }
     }
 
-
     #[test]
     fn span_to_range_multiline() {
         let _ = env_logger::builder().is_test(true).try_init();
 
-        const CONTENT: &'static str = chyrp_up!(
-            "Ey you!! Yes.., you there!",
-            "",
-            "GameChange",
-            "");
+        const CONTENT: &'static str = chyrp_up!("Ey you!! Yes.., you there!", "", "GameChange", "");
         let set = gen_literal_set(dbg!(CONTENT));
         let chunk = dbg!(CheckableChunk::from_literalset(set));
 
@@ -346,20 +359,31 @@ mod tests {
             },
         ];
 
-        const EXPECTED_RANGE: &[Range] = &[0..(26+1+0+1+10+1), 3..8, 28..38];
+        const EXPECTED_RANGE: &[Range] = &[0..(26 + 1 + 0 + 1 + 10 + 1), 3..8, 28..38];
 
         // note that this may only be single lines, since `///` implies separate literals
         // and as such multiple spans
         const FRAGMENT_STR: &[&'static str] = &[
-r#"Ey you!! Yes.., you there!
+            r#"Ey you!! Yes.., you there!
 
 GameChange
-"#, "you!!", "GameChange"];
+"#,
+            "you!!",
+            "GameChange",
+        ];
 
-        for (input, expected, fragment) in
-            itertools::cons_tuples(INPUTS.iter().zip(EXPECTED_RANGE.iter()).zip(FRAGMENT_STR.iter()))
-        {
-            log::trace!(">>>>>>>>>>>>>>>>\ninput: {:?}\nexpected: {:?}\nfragment:>{}<", input, expected, fragment);
+        for (input, expected, fragment) in itertools::cons_tuples(
+            INPUTS
+                .iter()
+                .zip(EXPECTED_RANGE.iter())
+                .zip(FRAGMENT_STR.iter()),
+        ) {
+            log::trace!(
+                ">>>>>>>>>>>>>>>>\ninput: {:?}\nexpected: {:?}\nfragment:>{}<",
+                input,
+                expected,
+                fragment
+            );
 
             let range = dbg!(input)
                 .to_content_range(&chunk)

--- a/src/span.rs
+++ b/src/span.rs
@@ -101,7 +101,7 @@ impl Span {
                 let range2 = (offset + start)..(offset + idx + 1);
                 assert!(range2.len() <= range.len());
                 if span.start.line == span.end.line {
-                    assert_eq!(range2.len(), span.end.column - span.start.column + 1);
+                    assert_eq!(range.len(), span.end.column - span.start.column + 1);
                 }
                 return Ok(range2);
             }

--- a/src/span.rs
+++ b/src/span.rs
@@ -100,6 +100,9 @@ impl Span {
             if line == self.end.line && col == self.end.column {
                 let range2 = (offset + start)..(offset + idx + 1);
                 assert!(range2.len() <= range.len());
+                if span.start.line == span.end.line {
+                    assert_eq!(range2.len(), span.end.column - span.end.column + 1);
+                }
                 return Ok(range2);
             }
 

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -407,11 +407,13 @@ mod tests {
 
     #[test]
     fn multiline_is_dbg_printable() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
         use crate::documentation::CheckableChunk;
         let chunk = CheckableChunk::from_str(
-r#"1
-207x
-@#$"#, indexmap::indexmap! { 0..13 => Span {
+r#"0
+2345
+7@n"#, indexmap::indexmap! { 0..10 => Span {
     start : LineColumn {
         line: 7usize,
         column: 8usize,
@@ -430,11 +432,15 @@ r#"1
                 start: LineColumn { line: 8usize, column: 0 },
                 end: LineColumn { line: 8usize, column: 3 }
             },
-            range: 2..7,
+            range: 2..6,
             replacements: vec!["whocares".to_owned()],
             description: None,
         };
-        let _suggestion = dbg!(suggestion);
+
+        let suggestion = dbg!(suggestion);
+
+        log::info!("fmt debug=\n{:?}\n<", suggestion);
+        log::info!("fmt display=\n{}\n<", suggestion);
 
     }
 }

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -411,26 +411,34 @@ mod tests {
 
         use crate::documentation::CheckableChunk;
         let chunk = CheckableChunk::from_str(
-r#"0
+            r#"0
 2345
-7@n"#, indexmap::indexmap! { 0..10 => Span {
-    start : LineColumn {
-        line: 7usize,
-        column: 8usize,
-    },
-    end : LineColumn {
-        line: 9usize,
-        column: 4usize,
-    }
-} });
+7@n"#,
+            indexmap::indexmap! { 0..10 => Span {
+                start : LineColumn {
+                    line: 7usize,
+                    column: 8usize,
+                },
+                end : LineColumn {
+                    line: 9usize,
+                    column: 4usize,
+                }
+            } },
+        );
 
         let suggestion = Suggestion {
             detector: Detector::Dummy,
             origin: ContentOrigin::TestEntity,
             chunk: &chunk,
             span: Span {
-                start: LineColumn { line: 8usize, column: 0 },
-                end: LineColumn { line: 8usize, column: 3 }
+                start: LineColumn {
+                    line: 8usize,
+                    column: 0,
+                },
+                end: LineColumn {
+                    line: 8usize,
+                    column: 3,
+                },
             },
             range: 2..6,
             replacements: vec!["whocares".to_owned()],
@@ -441,6 +449,5 @@ r#"0
 
         log::info!("fmt debug=\n{:?}\n<", suggestion);
         log::info!("fmt display=\n{}\n<", suggestion);
-
     }
 }

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -404,4 +404,37 @@ mod tests {
 
         assert_display_eq(suggestion, EXPECTED);
     }
+
+    #[test]
+    fn multiline_is_dbg_printable() {
+        use crate::documentation::CheckableChunk;
+        let chunk = CheckableChunk::from_str(
+r#"1
+207x
+@#$"#, indexmap::indexmap! { 0..13 => Span {
+    start : LineColumn {
+        line: 7usize,
+        column: 8usize,
+    },
+    end : LineColumn {
+        line: 9usize,
+        column: 4usize,
+    }
+} });
+
+        let suggestion = Suggestion {
+            detector: Detector::Dummy,
+            origin: ContentOrigin::TestEntity,
+            chunk: &chunk,
+            span: Span {
+                start: LineColumn { line: 8usize, column: 0 },
+                end: LineColumn { line: 8usize, column: 3 }
+            },
+            range: 2..7,
+            replacements: vec!["whocares".to_owned()],
+            description: None,
+        };
+        let _suggestion = dbg!(suggestion);
+
+    }
 }

--- a/src/traverse/iter.rs
+++ b/src/traverse/iter.rs
@@ -85,6 +85,8 @@ impl TraverseModulesIter {
         Ok(me)
     }
 
+    /// Create a new path with (almost) infinite depth bounds
+    #[allow(unused)]
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
         Self::with_depth_limit(path, usize::MAX)
     }

--- a/src/traverse/mod.rs
+++ b/src/traverse/mod.rs
@@ -360,23 +360,22 @@ pub(crate) fn extract(
                         }
                         // extract the full content span and range
                         let start = LineColumn { line: 1, column: 0 };
-                        let end = content.lines()
+                        let end = content
+                            .lines()
                             .enumerate()
                             .last()
-                            .map(|(idx, line)| (idx+1, line))
-                            .map(|(lineno, line)| {
-                                LineColumn {
-                                    line: lineno,
-                                    column: line.chars().count(),
-                                }
-                            }).ok_or_else(|| {
-                                anyhow!("Common mark / markdown file does not contain a single line")
+                            .map(|(idx, line)| (idx + 1, line))
+                            .map(|(lineno, line)| LineColumn {
+                                line: lineno,
+                                column: line.chars().count(),
+                            })
+                            .ok_or_else(|| {
+                                anyhow!(
+                                    "Common mark / markdown file does not contain a single line"
+                                )
                             })?;
 
-                        let span = Span {
-                            start,
-                            end
-                        };
+                        let span = Span { start, end };
                         let source_mapping = indexmap::indexmap! {
                            0..content.chars().count() => span
                         };


### PR DESCRIPTION
## What does this PR accomplish?

Does all handling of multiline literals, except for displaying, which must be handled in a separate PR.

Closes #37 which requires proper handling of chunks with multiline fragments

## Changes proposed by this PR:

* Calculate a full span for common mark files and the associated mapped range.
* Extract spans from multiline fragments.
* `feather_up!` for testability

