### PR TITLE
style/suggestion: no suggestion, less whitespaces

### DIFF
--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -586,7 +586,7 @@ impl<'s> SuggestionSet<'s> {
         self.per_file.len()
     }
 
-    /// Count the number of suggestions accross all files in total
+    /// Count the number of suggestions across all files in total
     pub fn total_count(&self) -> usize {
         self.per_file.iter().map(|(_origin, vec)| vec.len()).sum()
     }
@@ -673,6 +673,50 @@ mod tests {
    |        ^^^^^
    | - replacement_0, replacement_1, or replacement_2
    |
+   |   Possible spelling mistake found.
+"#;
+        assert_display_eq(suggestion, EXPECTED);
+    }
+
+    #[test]
+    fn fmt_0_no_suggestion() {
+        const CONTENT: &'static str = " Is it dyrck again?";
+        let chunk = CheckableChunk::from_str(
+            CONTENT,
+            indexmap::indexmap! { 0..18 => Span {
+                    start: LineColumn {
+                        line: 1,
+                        column: 0,
+                    },
+                    end: LineColumn {
+                        line: 1,
+                        column: 17,
+                    }
+                }
+            },
+        );
+
+        let suggestion = Suggestion {
+            detector: Detector::Dummy,
+            origin: ContentOrigin::TestEntity,
+            chunk: &chunk,
+            range: 7..12,
+            span: Span {
+                start: LineColumn { line: 1, column: 6 },
+                end: LineColumn {
+                    line: 1,
+                    column: 10,
+                },
+            },
+            replacements: vec![],
+            description: Some("Possible spelling mistake found.".to_owned()),
+        };
+
+        const EXPECTED: &'static str = r#"error: spellcheck(Dummy)
+  --> /tmp/test/entity:1
+   |
+ 1 |  Is it dyrck again?
+   |        ^^^^^
    |   Possible spelling mistake found.
 "#;
         assert_display_eq(suggestion, EXPECTED);

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -451,7 +451,7 @@ impl<'s> fmt::Display for Suggestion<'s> {
 
         error.apply_to(replacement).fmt(formatter)?;
 
-        if self.replacements.len() > 0 {
+        if !self.replacements.is_empty() {
             formatter.write_str("\n")?;
             context_marker
                 .apply_to(format!("{:>width$}", "|\n", width = indent + 1))

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -450,22 +450,21 @@ impl<'s> fmt::Display for Suggestion<'s> {
         };
 
         error.apply_to(replacement).fmt(formatter)?;
-        formatter.write_str("\n")?;
 
-        context_marker
-            .apply_to(format!("{:>width$}", "|\n", width = indent + 1))
-            .fmt(formatter)?;
+        if self.replacements.len() > 0 {
+            formatter.write_str("\n")?;
+            context_marker
+                .apply_to(format!("{:>width$}", "|\n", width = indent + 1))
+                .fmt(formatter)?;
+            context_marker
+                .apply_to(format!("{:>width$}", "|", width = indent))
+                .fmt(formatter)?;
+        }
 
-        context_marker
-            .apply_to(format!("{:>width$}", "|", width = indent))
-            .fmt(formatter)?;
         if let Some(ref description) = self.description {
             writeln!(formatter, "   {}", description)?;
         }
-
-        context_marker
-            .apply_to(format!("{:>width$}", "|\n", width = indent + 1))
-            .fmt(formatter)
+        Ok(())
     }
 }
 
@@ -675,7 +674,6 @@ mod tests {
    | - replacement_0, replacement_1, or replacement_2
    |
    |   Possible spelling mistake found.
-   |
 "#;
         assert_display_eq(suggestion, EXPECTED);
     }
@@ -752,7 +750,6 @@ mod tests {
    | - replacement_0, replacement_1, or replacement_2
    |
    |   Possible spelling mistake found.
-   |
 "#;
 
         assert_display_eq(suggestion, EXPECTED);
@@ -817,7 +814,6 @@ mod tests {
    | - replacement_0, replacement_1, or replacement_2
    |
    |   Possible spelling mistake found.
-   |
 "#;
 
         assert_display_eq(suggestion, EXPECTED);


### PR DESCRIPTION
## What does this PR accomplish? #93 


 * [ ] Bug Fix
 * [ ] Feature
 * [x] Style
 * [ ] Documentation

closes #93 

## Changes proposed by this PR:

- Only add additional spaces in case [replacements](https://github.com/drahnr/cargo-spellcheck/blob/master/src/suggestion.rs#L420) has some content (some suggestion).
- Remove additional `|` and white space in the end.

## Notes to reviewer:
