### PR TITLE
fix/config: default dirs should always be kept

### DIFF
--- a/.concourse.yml
+++ b/.concourse.yml
@@ -11,6 +11,27 @@ resources:
     branch: master
     uri: https://github.com/drahnr/cargo-spellcheck.git
 
+- name: git-rustlang-rust
+  type: git
+  source:
+    branch: master
+    uri: https://github.com/rust-lang/rust.git
+
+- name: git-spearow-juice
+  type: git
+  source:
+    branch: master
+    uri: https://github.com/spearow/juice.git
+
+- name: binary-releases
+  type: s3
+  source:
+    endpoint: https://minio.spearow.io
+    bucket: cargo-spellcheck-releases
+    regexp: cargo-spellcheck-(.*)
+    access_key_id: ((minio-access-key))
+    secret_access_key: ((minio-secret-key))
+
 - name: github-release
   type: github-release
   source:
@@ -38,17 +59,25 @@ resources:
     repository: quay.io/drahnr/rust-glibc-builder
 
 jobs:
+####################################################################################
+#                              P U L L - R E Q U E S T
+####################################################################################
   - name: pr-validate
     build_logs_to_retain: 10
     public: true
-    serial: true
     plan:
-    - get: git-pull-request-resource
-      resource: git-pull-request-resource
-      version: every
-      trigger: true
+    - in_parallel:
+      - get: git-pull-request-resource
+        resource: git-pull-request-resource
+        version: every
+        trigger: true
 
-    - get: env-glibc
+      - get: env-glibc
+
+      - get: git-rustlang-rust
+
+      - get: git-spearow-juice
+        params: {depth: 3}
 
     - in_parallel:
       - put: git-pull-request-resource
@@ -178,55 +207,162 @@ jobs:
             context: meta-check
             status: failure
 
-      - task: run-check
-        timeout: 15m
-        image: env-glibc
-        config:
-          platform: linux
-          inputs:
-          - name: git-pull-request-resource
-          run:
-            # user: root
-            path: sh
-            args:
-            - -exc
-            - |
-              export CARGO_HOME="$(pwd)/../cargo"
-              sudo chown $(whoami): -Rf ${CARGO_HOME} .
-              cargo +stable run -- --version
-              cargo +stable run -- spellcheck demo/Cargo.toml || echo "$? - Found some errors"
-              cargo +stable run -- spellcheck demo/src/main.rs || echo "$? - Found some errors"
-              cargo +stable run -- spellcheck demo/ || echo "$? - Found some errors"
-              # assure pipes work
-              cargo +stable run -- spellcheck | grep -C 10 "F"
-              cargo +stable run -- spellcheck > dump
-            dir: git-pull-request-resource
-          caches:
-          - path: cargo
+      - do:
+        - task: run-check
+          timeout: 15m
+          image: env-glibc
+          config:
+            platform: linux
+            inputs:
+            - name: git-pull-request-resource
+            outputs:
+            - name: binary
+            run:
+              # user: root
+              path: sh
+              args:
+              - -exc
+              - |
+                export CARGO_HOME="$(pwd)/../cargo"
+                sudo chown $(whoami): -Rf ${CARGO_HOME} .
+                cargo +stable run --release -- --version
+                cargo +stable run --release -- spellcheck demo/Cargo.toml || echo "$? - Found some errors"
+                cargo +stable run --release -- spellcheck demo/src/main.rs || echo "$? - Found some errors"
+                cargo +stable run --release -- spellcheck demo/ || echo "$? - Found some errors"
+                # assure pipes work
+                cargo +stable run --release -- spellcheck | grep -C 10 "F"
+                cargo +stable run --release -- spellcheck > dump
 
-        on_success:
-          put: git-pull-request-resource
-          params:
-            path: git-pull-request-resource
-            context: run-check
-            status: success
+                sudo cp -vf target/release/cargo-spellcheck ../binary/cargo-spellcheck-$(git rev-parse HEAD)
+              dir: git-pull-request-resource
+            caches:
+            - path: cargo
 
-        on_failure:
-          put: git-pull-request-resource
-          params:
-            path: git-pull-request-resource
-            context: run-check
-            status: failure
+          on_success:
+            put: git-pull-request-resource
+            params:
+              path: git-pull-request-resource
+              context: run-check
+              status: success
 
+          on_failure:
+            put: git-pull-request-resource
+            params:
+              path: git-pull-request-resource
+              context: run-check
+              status: failure
+        - in_parallel:
+          - put: git-pull-request-resource
+            params:
+              path: git-pull-request-resource
+              context: test-spearow-juice
+              status: pending
+
+          - put: git-pull-request-resource
+            params:
+              path: git-pull-request-resource
+              context: test-rustlang-rust
+              status: pending
+
+        - in_parallel:
+          - task: pr-test-on-spearow-juice
+            timeout: 15m
+            image: env-glibc
+            config:
+              platform: linux
+              inputs:
+              - name: binary
+              - name: git-spearow-juice
+              run:
+                path: sh
+                args:
+                - -exc
+                - |
+                  export CARGO_HOME="$(pwd)/../cargo"
+                  sudo chown $(whoami): -Rf ${CARGO_HOME} .
+                  mkdir -p ${CARGO_HOME}/bin/
+                  sudo cp -vf ../binary/cargo-spellcheck-* ${CARGO_HOME}/bin/cargo-spellcheck
+                  sudo chmod +x ${CARGO_HOME}/bin/cargo-spellcheck
+
+                  ${CARGO_HOME}/bin/cargo-spellcheck spellcheck -vvv
+                dir: git-spearow-juice
+              caches:
+              - path: cargo
+
+            on_success:
+              put: git-pull-request-resource
+              params:
+                path: git-pull-request-resource
+                context: test-spearow-juice
+                status: success
+
+            on_failure:
+              put: git-pull-request-resource
+              params:
+                path: git-pull-request-resource
+                context: test-spearow-juice
+                status: failure
+      
+
+          - task: pr-test-on-rustlang-rust
+            timeout: 15m
+            image: env-glibc
+            config:
+              platform: linux
+              inputs:
+              - name: binary
+                resource: binary-pr
+                passed: [run-check]
+              - name: git-rustlang-rust
+              run:
+                path: sh
+                args:
+                - -exc
+                - |
+                  export CARGO_HOME="$(pwd)/../cargo"
+                  sudo chown $(whoami): -Rf ${CARGO_HOME} .
+                  mkdir -p ${CARGO_HOME}/bin/
+                  sudo cp -vf ../binary/cargo-spellcheck-* ${CARGO_HOME}/bin/cargo-spellcheck
+                  sudo chmod +x ${CARGO_HOME}/bin/cargo-spellcheck
+
+                  git submodule update --init
+                  ${CARGO_HOME}/bin/cargo-spellcheck spellcheck -vvv
+                dir: git-rustlang-rust
+              caches:
+              - path: cargo
+
+            on_success:
+              put: git-pull-request-resource
+              params:
+                path: git-pull-request-resource
+                context: test-rustlang-rust
+                status: success
+
+            on_failure:
+              put: git-pull-request-resource
+              params:
+                path: git-pull-request-resource
+                context: test-rustlang-rust
+                status: failure
+  
+  ####################################################################################
+  #                                 M A S T E R
+  ####################################################################################
   - name: master-validate
     build_logs_to_retain: 10
     public: true
     serial: true
     plan:
-    - get: env-glibc
-    - get: git-repo
-      resource: git-clone-resource
-      trigger: true
+    - in_parallel:
+      - get: env-glibc
+      - get: git-repo
+        resource: git-clone-resource
+        trigger: true
+
+      - get: git-rustlang-rust
+
+      - get: git-spearow-juice
+        params: {depth: 3}
 
     - in_parallel:
       - task: validate-compile
@@ -268,34 +404,92 @@ jobs:
               sudo chown $(whoami): -Rf ${CARGO_HOME} .
               rustc +stable --version --verbose
               cargo +stable fmt -- --check
-              cargo spellcheck check && echo "Actually no spelling mistakes found!" || echo "Well, just testdrive anyways"
             dir: git-repo
           caches:
           - path: cargo
 
-      - task: just-run
-        timeout: 15m
-        image: env-glibc
-        config:
-          platform: linux
-          inputs:
-          - name: git-repo
-          run:
-            # user: root
-            path: sh
-            args:
-            - -exc
-            - |
-              export CARGO_HOME="$(pwd)/../cargo"
-              sudo chown $(whoami): -Rf ${CARGO_HOME} .
-              cargo +stable run -- --version
-              cargo +stable run -- spellcheck demo/Cargo.toml
-              cargo +stable run -- spellcheck demo/src/main.rs
-              cargo +stable run -- spellcheck demo/
-            dir: git-repo
-          caches:
-          - path: cargo
+      - do:
+        - task: just-run
+          timeout: 15m
+          image: env-glibc
+          config:
+            platform: linux
+            inputs:
+            - name: git-repo
+            outputs:
+            - name: binary
+            run:
+              # user: root
+              path: sh
+              args:
+              - -exc
+              - |
+                export CARGO_HOME="$(pwd)/../cargo"
+                sudo chown $(whoami): -Rf ${CARGO_HOME} .
+                cargo +stable run --release -- --version
+                cargo +stable run --release -- spellcheck demo/Cargo.toml
+                cargo +stable run --release -- spellcheck -vvvv demo/src/main.rs
+                cargo +stable run --release -- spellcheck demo/
+                cargo +stable run --release
 
+                sudo cp -vf target/release/cargo-spellcheck ../binary/cargo-release-$(git rev-parse HEAD)
+              dir: git-repo
+            caches:
+            - path: cargo
+
+        - in_parallel:
+
+          - task: test-on-spearow-juice
+            timeout: 15m
+            image: env-glibc
+            config:
+              platform: linux
+              inputs:
+              - name: binary
+              - name: git-spearow-juice
+              run:
+                path: sh
+                args:
+                - -exc
+                - |
+                  export CARGO_HOME="$(pwd)/../cargo"
+                  sudo chown $(whoami): -Rf ${CARGO_HOME} .
+                  mkdir -p ${CARGO_HOME}/bin/
+                  sudo cp -vf ../binary/cargo-spellcheck-* ${CARGO_HOME}/bin/cargo-spellcheck
+                  sudo chmod +x ${CARGO_HOME}/bin/cargo-spellcheck
+
+                  ${CARGO_HOME}/bin/cargo-spellcheck spellcheck -vvv
+                dir: git-spearow-juice
+              caches:
+              - path: cargo
+
+
+          - task: test-on-rustlang-rust
+            timeout: 15m
+            image: env-glibc
+            config:
+              platform: linux
+              inputs:
+              - name: binary
+                resource: binary-master
+                passed: [just-run]
+              - name: git-rustlang-rust
+              run:
+                path: sh
+                args:
+                - -exc
+                - |
+                  export CARGO_HOME="$(pwd)/../cargo"
+                  sudo chown $(whoami): -Rf ${CARGO_HOME} .
+                  mkdir -p ${CARGO_HOME}/bin/
+                  sudo cp -vf ../binary/cargo-spellcheck-* ${CARGO_HOME}/bin/cargo-spellcheck
+                  sudo chmod +x ${CARGO_HOME}/bin/cargo-spellcheck
+
+                  git submodule update --init
+                  ${CARGO_HOME}/bin/cargo-spellcheck spellcheck -vvv
+                dir: git-rustlang-rust
+              caches:
+              - path: cargo
 
   - name: publish-github-release
     build_logs_to_retain: 5
@@ -325,7 +519,6 @@ jobs:
             - |
               export CARGO_HOME="$(pwd)/../cargo"
               sudo chown $(whoami): -Rf ${CARGO_HOME} .
-
 
               export RI_BASE_DIR="../release-info"
               export RI_ARTIFACTS_DIR="${RI_BASE_DIR}/artifacts"
@@ -358,7 +551,7 @@ jobs:
               for TARGET in x86_64-unknown-linux-gnu ; do
                 echo "Prepping ${TARGET} ..."
                 cargo build --release --target "${TARGET}" && \
-                cp -vf "target/${TARGET}/release/cargo-spellcheck" "${RI_ARTIFACTS_DIR}/cargo-spellcheck-${TARGET}"
+                cp -vf "target/${TARGET}/release/cargo-spellcheck" "${RI_ARTIFACTS_DIR}/${TARGET}/${RI_NAME_FILE}"
                 echo "Prepped ${TARGET} ."
                 echo ""
               done
@@ -371,3 +564,10 @@ jobs:
         commitish: release-info/COMMITISH
         globs:
         - release-info/artifacts/*
+
+    - put: binary-releases
+      params:
+        file: ./release-info/artifacts/x86_64-unknown-linux-gnu/cargo-release-(.*)
+        acl: public-read
+     
+     

--- a/.config/spellcheck.conf
+++ b/.config/spellcheck.conf
@@ -1,0 +1,12 @@
+[Hunspell]
+# lang and name of `.dic` file
+lang = "en_US"
+
+[Hunspell.quirks]
+# transforms words that are provided by the tokenizer
+# into word fragments based on the capture groups which are to be checked.
+# If no capture groups are present, the matched word is whitelisted.
+transform_regex = ["^'([^\\s])'$", "^[0-9]+x$"]
+# accepts `alphabeta` variants if the checker provides a replacement suggestion
+# of `alpha-beta`.
+allow_concatenation = true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,16 +5,20 @@ Thank you for submitting a PR to cargo-spellcheck!
 ## What does this PR accomplish?
 
 <!---
-Choose all that apply.
-Also, mention the linked issue here.
-This will magically close the issue once the PR is merged.
+Delete all that do not apply:
 -->
 
- * [ ] Bug Fix
- * [ ] Feature
- * [ ] Documentation
+ * 🩹 Bug Fix
+ * 🦚 Feature
+ * 📙 Documentation
+ * 🦣 Legacy
+ * 🪣 Misc
 
-closes # .
+<!---
+Mention the linked issue here.
+This will magically close the issue once the PR is merged.
+-->
+Closes # .
 
 ## Changes proposed by this PR:
 
@@ -27,4 +31,13 @@ Tell the reviewer What changed, Why, and How were you able to accomplish that?
 <!---
 Leave a message to whoever is going to review this PR.
 Mainly, pointers to review the PR, and how they can test it.
+If things are still WIP or feedback on particulr impl details
+are wanted, state them here too.
 -->
+
+
+## 📜 Checklist
+
+ * [ ] Works on the `./demo` sub directory
+ * [ ] Test coverage is excellent and passes
+ * [ ] Documentation is thorough

--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ lang = "en_US"
 # Linux: [ /usr/share/myspell ]
 # Windows: []
 # macOS [ /home/alice/Libraries/hunspell, /Libraries/hunspell ]
-search_dirs = []
+
+# overwrites the default os specific search dirs
+# search_dirs = []
+
+# adds additional dictionary lookup dirs
 extra_dictonaries = []
 
 [Hunspell.quirks]

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -104,7 +104,7 @@ where
                 .hunspell
                 .as_ref()
                 .expect("Must be Some(HunspellConfig) if is_enabled returns true");
-            let mut suggestions = self::hunspell::HunspellChecker::check(documentation, config)?;
+            let suggestions = self::hunspell::HunspellChecker::check(documentation, config)?;
             collective.join(suggestions);
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -624,7 +624,7 @@ search_dirs = ["/search/1", "/search/2"]
         let search_dirs: Option<_> = search_dirs.as_ref().clone();
         let search_dirs = search_dirs.expect("Must be some search dirs");
         #[cfg(target_os = "linux")]
-        assert_eq!(search_dirs.len(), 4);
+        assert_eq!(search_dirs.len(), 5);
 
         #[cfg(target_os = "windows")]
         assert_eq!(search_dirs.len(), 2);

--- a/src/documentation/markdown.rs
+++ b/src/documentation/markdown.rs
@@ -47,11 +47,11 @@ impl<'a> PlainOverlay<'a> {
     }
 
     /// ranges are mapped `cmakr reduced/plain -> raw`
-    fn extract_plain_with_mapping(markdown: &str) -> (String, IndexMap<Range, Range>) {
-        let mut plain = String::with_capacity(markdown.chars().count());
+    fn extract_plain_with_mapping(cmark: &str) -> (String, IndexMap<Range, Range>) {
+        let mut plain = String::with_capacity(cmark.len());
         let mut mapping = indexmap::IndexMap::with_capacity(128);
 
-        let parser = Parser::new_ext(markdown, Options::all());
+        let parser = Parser::new_ext(cmark, Options::all());
 
         let rust_fence =
             pulldown_cmark::CodeBlockKind::Fenced(pulldown_cmark::CowStr::Borrowed("rust"));


### PR DESCRIPTION
## What does this PR accomplish?

Fix a bug when custom search dirs are provided, the default ones are dropped, even if the kv is `search_dirs = []`.

## Changes proposed by this PR:

Makes sure the default search paths are kept, but at the lowest priority.