### PR TITLE
fix/commonmark: insert additional spaces after list items and at list start

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ mistakes are found instead of `0`.
   * [ ] Handle doctests with ` ```rust` as virtual files [#43](https://github.com/drahnr/cargo-spellcheck/issues/43)
   * [ ] Verify all types of links [#44](https://github.com/drahnr/cargo-spellcheck/issues/44)
 * [x] Check `README.md` files [#37](https://github.com/drahnr/cargo-spellcheck/issues/37)
-* [ ] Check mdbook `book.toml` file trees [#62](https://github.com/drahnr/cargo-spellcheck/issues/62)
 * [x] Improve interactive user interface with `crossterm`
 * [x] Ellipsize overly long statements with `...` [#42](https://github.com/drahnr/cargo-spellcheck/issues/42)
 * [ ] Learn topic lingo and filter false-positive-suggestions [#41](https://github.com/drahnr/cargo-spellcheck/issues/41)

--- a/src/documentation/markdown.rs
+++ b/src/documentation/markdown.rs
@@ -141,6 +141,7 @@ impl<'a> PlainOverlay<'a> {
                     match tag {
                         Tag::Table(_) => {
                             skip_table_text = false;
+                            Self::newlines(&mut plain, 1);
                         }
                         Tag::Link(_link_type, _url, _title) => {
                             // the actual rendered content is in a text section
@@ -623,12 +624,19 @@ d"#,
         // or handle a list of mute tags to simply ignore.
         cmark_reduction_test(
             r#"
+00
+
 |a|b|c
 |-|-|-
 |p|q|r
+
+ff
 "#,
-            r#""#,
-            0,
+            r#"00
+
+
+ff"#,
+            2,
         );
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

 * 🩹 Bug Fix

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes #109.

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->


## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
