### PR TITLE
refactor/action: rewrite correct_lines purely based on spans

### DIFF
--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -88,8 +88,7 @@ where
     II: IntoIterator<IntoIter = I, Item = Patch>,
     I: Iterator<Item = Patch>,
 {
-    let patches = patches.into_iter();
-    let mut patches = patches.peekable();
+    let mut patches = patches.into_iter().peekable();
 
     let mut source_iter =
         iter_with_line_column_from(source_buffer.as_str(), LineColumn { line: 1, column: 0 })

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -397,7 +397,7 @@ Icecream truck"#
             replace_span: (1_usize, 0..1).try_into().unwrap(),
             replacement: "Y".to_owned(),
         }];
-        verify_correction!("TFFU", bandaids, "YFFU");
+        verify_correction!("T🐠🐠U", bandaids, "Y🐠🐠U");
     }
 
     #[test]
@@ -410,7 +410,7 @@ Icecream truck"#
             replace_span: (1_usize, 1..3).try_into().unwrap(),
             replacement: "Y".to_owned(),
         }];
-        verify_correction!("TFFU", bandaids, "TYU");
+        verify_correction!("T🐠🐠U", bandaids, "TYU");
     }
 
     #[test]
@@ -423,7 +423,7 @@ Icecream truck"#
             replace_span: (1_usize, 3..4).try_into().unwrap(),
             replacement: "Y".to_owned(),
         }];
-        verify_correction!("TFFU", bandaids, "TFFY");
+        verify_correction!("T🐠🐠U", bandaids, "T🐠🐠Y");
     }
 
     #[test]
@@ -440,7 +440,7 @@ Icecream truck"#
             },
             content: "Q".to_owned(),
         }];
-        verify_correction!("ABC", patches, "QABC");
+        verify_correction!("A🐢C", patches, "QA🐢C");
     }
 
     #[test]
@@ -457,7 +457,7 @@ Icecream truck"#
             },
             content: "Q".to_owned(),
         }];
-        verify_correction!("ABC", patches, "ABQC");
+        verify_correction!("A🐢C", patches, "A🐢QC");
     }
     #[test]
     fn patch_injection_3() {
@@ -473,6 +473,6 @@ Icecream truck"#
             },
             content: "Q".to_owned(),
         }];
-        verify_correction!("ABC", patches, "ABCQ");
+        verify_correction!("A🐢C", patches, "A🐢CQ");
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use std::io::Read;
 pub fn iter_with_line_column_from<'a>(
     s: &'a str,
     start_point: LineColumn,
-) -> impl Iterator<Item = (char, usize, LineColumn)> + 'a {
+) -> impl Iterator<Item = (char, usize, usize, LineColumn)> + 'a {
     #[derive(Clone)]
     struct State {
         cursor: LineColumn,
@@ -19,9 +19,10 @@ pub fn iter_with_line_column_from<'a>(
         previous_char_was_newline: false,
     };
 
-    s.chars()
+    s.char_indices()
         .enumerate()
-        .scan(initial, |state, (idx, c)| -> Option<_> {
+        .map(|(idx, (byte_offset, c))| (idx, byte_offset, c))
+        .scan(initial, |state, (idx, byte_offset, c)| -> Option<_> {
             let cursor = state.cursor;
             state.previous_char_was_newline = c == '\n';
             if state.previous_char_was_newline {
@@ -30,14 +31,14 @@ pub fn iter_with_line_column_from<'a>(
             } else {
                 state.cursor.column += 1;
             }
-            Some((c, idx, cursor))
+            Some((c, byte_offset, idx, cursor))
         })
 }
 
 /// Iterate over annotated chars starting from line 1 and column 0 assuming `s` starts there.
 pub fn iter_with_line_column<'a>(
     s: &'a str,
-) -> impl Iterator<Item = (char, usize, LineColumn)> + 'a {
+) -> impl Iterator<Item = (char, usize, usize, LineColumn)> + 'a {
     iter_with_line_column_from(s, LineColumn { line: 1, column: 0 })
 }
 
@@ -62,16 +63,16 @@ where
         .expect("Must read successfully");
 
     let extraction = iter_with_line_column(s.as_str())
-        .skip_while(|(_c, _idx, cursor)| {
+        .skip_while(|(_c, _byte_offset, _idx, cursor)| {
             cursor.line < span.start.line
                 || (cursor.line == span.start.line && cursor.column < span.start.column)
         })
-        .take_while(|(_c, _idx, cursor)| {
+        .take_while(|(_c, _byte_offset, _idx, cursor)| {
             cursor.line < span.end.line
                 || (cursor.line == span.end.line && cursor.column <= span.end.column)
         })
         .fuse()
-        .map(|(c, _idx, _cursor)| c)
+        .map(|(c, _byte_offset, _idx, _cursor)| c)
         .collect::<String>();
     // log::trace!("Loading {:?} from line >{}<", &range, &line);
     Ok(extraction)
@@ -119,7 +120,7 @@ d"#;
         ];
 
         iter_with_line_column(S).zip(EXPECT.into_iter()).for_each(
-            |((c, _idx, lc), (expected_lc, expected_c))| {
+            |((c, _byte_offset, _idx, lc), (expected_lc, expected_c))| {
                 assert_eq!(lc, expected_lc.clone());
                 assert_eq!(c, expected_c.clone());
             },


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

Replaces the correction algorithm.

 * 🩹 Bug Fix
 * 🦚 Feature

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes #116  .

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->



Previously a line based algortihm was employed which caused some issues in #95 and #116 .

The new implementation works purely on `Span`s wrapped in `Patch`es, which now also handles multiline replacements properly and forces a clear boundary between `Patch` and `Bandaid`.


## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->

It's now entirely the concern of the checker to provide sane spans and proper wrapping with comment markers (i.e. `///` ) from within the `Checker`s - this is mostly necessary for #95 .

## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
