### PR TITLE
Support for developer comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "pulldown-cmark",
+ "ra_ap_syntax",
  "rayon",
  "regex",
  "serde",
@@ -504,6 +505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "directories"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +541,12 @@ dependencies = [
  "serde",
  "strsim 0.9.3",
 ]
+
+[[package]]
+name = "drop_bomb"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
 
 [[package]]
 name = "dtoa"
@@ -1206,6 +1219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
 
 [[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
 name = "openssl"
 version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1386,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ra_ap_parser"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2410f28bddc8d185f4a7e1b5c66487dcbf7f27d6d7ba4d69063cfee9e98e4dc"
+dependencies = [
+ "drop_bomb",
+]
+
+[[package]]
+name = "ra_ap_stdx"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e984205a9ece7a6efaac42ff017faf3433c4fbfa3d21ee963670beceb0413b7c"
+
+[[package]]
+name = "ra_ap_syntax"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24394ab74f064c3a1be784db5b55d2d06984fbed62d8202c6341c8416fa92d6"
+dependencies = [
+ "arrayvec",
+ "indexmap",
+ "itertools",
+ "once_cell",
+ "ra_ap_parser",
+ "ra_ap_stdx",
+ "ra_ap_test_utils",
+ "ra_ap_text_edit",
+ "rowan",
+ "rustc-ap-rustc_lexer",
+ "rustc-hash",
+ "serde",
+ "smol_str",
+]
+
+[[package]]
+name = "ra_ap_test_utils"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6906392ce758c2aa6ef8db109a163728da8fa99700a482b0c3615a63d63e0cb"
+dependencies = [
+ "difference",
+ "ra_ap_stdx",
+ "rustc-hash",
+ "serde_json",
+ "text-size",
+]
+
+[[package]]
+name = "ra_ap_text_edit"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65582a9e095bf4cc2e2bd398d1014fed048ca542b6b76fdb757e91944cf26456"
+dependencies = [
+ "text-size",
 ]
 
 [[package]]
@@ -1629,6 +1706,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e081ed6eacce09e243b619ab90f069c27b0cff8a6d0eb8ad2ec935b65853798"
+dependencies = [
+ "rustc-hash",
+ "smol_str",
+ "text-size",
+ "thin-dst",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1727,15 @@ dependencies = [
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils 0.7.2",
+]
+
+[[package]]
+name = "rustc-ap-rustc_lexer"
+version = "686.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b04cd2159495584d976d501c5394498470c2e94e4f0cebb8186562d407a678"
+dependencies = [
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1822,6 +1920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
+name = "smol_str"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ca0f7ce3a29234210f0f4f0b56f8be2e722488b95cb522077943212da3b32eb"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "socket2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +2018,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "text-size"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03e7efdedc3bc78cb2337f1e2785c39e45f5ef762d9e4ebb137fff7380a6d8a"
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +2031,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "thin-dst"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c46be180f1af9673ebb27bc1235396f61ef6965b3fe0dbb2e624deb604f0e"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ env_logger = "0.8"
 console = "0.13"
 indexmap = { version = "1", features=["rayon"] }
 enumflags2 = "0.6"
+ra_ap_syntax = "0.0.23"
+regex = "1.4.2"
 # for the config file
 toml = "0.5"
 # for parsing and extracting elements from Cargo.toml
@@ -32,7 +34,6 @@ pulldown-cmark = "0.8"
 itertools = "0.9"
 crossterm = "0.18"
 fancy-regex = "0.4"
-regex = "1.4.2"
 signal-hook = "0.1"
 rayon = "1.5"
 

--- a/demo/src/nested/fragments.rs
+++ b/demo/src/nested/fragments.rs
@@ -6,8 +6,13 @@ mod simple;
 
 mod enumerate;
 
+// Shud be chcked now
+// Verify **some** _super_ *duper* [markdown](https://ahoi.io/).
 struct X;
 
+/*
+ * Also check thiz one
+ */
 impl X {
 	/// New, as in new. But also not.
 	///
@@ -23,7 +28,3 @@ impl X {
 		unimplemented!()
 	}
 }
-
-
-// Should not be checked for now
-// Verify **some** _super_ *duper* [markdown](https://ahoi.io/).

--- a/src/documentation/cluster.rs
+++ b/src/documentation/cluster.rs
@@ -101,6 +101,10 @@ impl Clusters {
             self.set.push(comment);
         }
     }
+
+    fn ensure_sorted(&mut self) {
+        self.set.sort_by(|ls1, ls2| ls1.coverage.cmp(&ls2.coverage));
+    }
 }
 
 impl TryFrom<&str> for Clusters {
@@ -113,6 +117,7 @@ impl TryFrom<&str> for Clusters {
             .map_err(|e| anyhow!("Failed to parse content to stream").context(e))?;
         chunk.parse_token_tree(source, stream)?;
         chunk.parse_developer_comments(source);
+        chunk.ensure_sorted();
         Ok(chunk)
     }
 }

--- a/src/documentation/cluster.rs
+++ b/src/documentation/cluster.rs
@@ -1,6 +1,7 @@
 //! Cluster `proc_macro2::Literal`s into `LiteralSets`
 
 use super::{trace, LiteralSet, Spacing, TokenTree, TrimmedLiteral, TryInto};
+use crate::documentation::developer::extract_developer_comments;
 use crate::documentation::Range;
 use crate::Span;
 use anyhow::{anyhow, Error, Result};
@@ -93,6 +94,13 @@ impl Clusters {
         }
         Ok(())
     }
+
+    fn parse_developer_comments(&mut self, source: &str) {
+        let developer_comments = extract_developer_comments(source);
+        for comment in developer_comments {
+            self.set.push(comment);
+        }
+    }
 }
 
 impl TryFrom<&str> for Clusters {
@@ -104,6 +112,7 @@ impl TryFrom<&str> for Clusters {
         let stream = syn::parse_str::<proc_macro2::TokenStream>(source)
             .map_err(|e| anyhow!("Failed to parse content to stream").context(e))?;
         chunk.parse_token_tree(source, stream)?;
+        chunk.parse_developer_comments(source);
         Ok(chunk)
     }
 }

--- a/src/documentation/cluster.rs
+++ b/src/documentation/cluster.rs
@@ -95,6 +95,8 @@ impl Clusters {
         Ok(())
     }
 
+    /// From the given source text, extracts developer comments to `LiteralSet`s and adds them
+    /// to this `Clusters`
     fn parse_developer_comments(&mut self, source: &str) {
         let developer_comments = extract_developer_comments(source);
         for comment in developer_comments {
@@ -102,6 +104,8 @@ impl Clusters {
         }
     }
 
+    /// Sort the `LiteralSet`s in this `Cluster` by start line descending, to ensure that the
+    /// comments higher up in the source file appear first to the user
     fn ensure_sorted(&mut self) {
         self.set.sort_by(|ls1, ls2| ls1.coverage.cmp(&ls2.coverage));
     }

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -37,7 +37,7 @@ lazy_static::lazy_static! {
 /// A string token from a source string with the location at which it occurs in the source string
 /// in 0 indexed bytes
 #[derive(Debug)]
-pub struct TokenWithLocation {
+struct TokenWithLocation {
   /// The full contents of this token, including pre/post characters (like '//')
   content: String,
   /// The location of the start of this token in the source string, in bytes
@@ -47,7 +47,7 @@ pub struct TokenWithLocation {
 /// A string token from a source string with the location at which it occurs in the source string
 /// as line on which it occurs (1 indexed) and the column of its first character (0 indexed)
 #[derive(Debug)]
-pub struct TokenWithLineColumn {
+struct TokenWithLineColumn {
   /// The full contents of this token, including pre/post characters (like '//')
   content: String,
   /// The first line on which the token appears in the source file (1 indexed)
@@ -105,7 +105,7 @@ impl TokenType {
 /// A token from a source string with its variant (TokenType) and the line and column on which it
 /// occurs according to the description for `TokenWithLineColumn`
 #[derive(Debug)]
-pub struct TokenWithType {
+struct TokenWithType {
   /// Is the token a block developer comment, line developer comment or something else
   kind: TokenType,
   /// The full contents of this token, including pre/post characters (like '//')
@@ -146,7 +146,7 @@ pub fn extract_developer_comments(source: &str) -> Vec<LiteralSet> {
 }
 
 /// Creates a series of `TokenWithLocation`s from a source string
-pub fn source_to_tokens_with_location(source: &str) -> Vec<TokenWithLocation> {
+fn source_to_tokens_with_location(source: &str) -> Vec<TokenWithLocation> {
   let ra_tokens = tokenize(source).0;
   let mut tokens = vec!();
   let mut location = 0;
@@ -163,7 +163,7 @@ pub fn source_to_tokens_with_location(source: &str) -> Vec<TokenWithLocation> {
 
 /// Converts a series of `TokenWithLocation`s to `TokenWithLineColumn`s. Requires the source string
 /// to calculate line & column from location.
-pub fn tokens_with_location_to_tokens_with_line_and_column
+fn tokens_with_location_to_tokens_with_line_and_column
     (source: &str, tokens_in: Vec<TokenWithLocation>) -> Vec<TokenWithLineColumn> {
   tokens_in.into_iter()
       .map(|t| TokenWithLineColumn {
@@ -175,13 +175,13 @@ pub fn tokens_with_location_to_tokens_with_line_and_column
 
 /// Given a string, calculates the 1 indexed line number of the line on which the final character
 /// of the string appears
-pub fn count_lines(fragment: &str) -> usize {
+fn count_lines(fragment: &str) -> usize {
   fragment.chars().into_iter().filter(|c| *c == '\n').count() + 1
 }
 
 /// Given a string, calculates the 0 indexed column number of the character *just after* the final
 /// character in the string
-pub fn calculate_column(fragment: &str) -> usize {
+fn calculate_column(fragment: &str) -> usize {
   match fragment.rfind('\n') {
     Some(p) => fragment.chars().count() - fragment[..p].chars().count() - 1,
     None => fragment.chars().count()

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -4,7 +4,8 @@ use regex::Regex;
 
 use super::*;
 
-struct TokenWithLocation {
+#[derive(Debug)]
+pub struct TokenWithLocation {
   content: String,
   location: usize
 }
@@ -16,6 +17,21 @@ struct TokenWithLineColumn {
   column: usize
 }
 
+pub fn source_to_tokens_with_location(source: &str) -> Vec<TokenWithLocation> {
+  let ra_tokens = tokenize(source).0;
+  let mut tokens = vec!();
+  let mut location = 0;
+  for token in ra_tokens {
+    let length = usize::from(token.len);
+    tokens.push(TokenWithLocation{
+      content: source[location..location + length].to_string(),
+      location
+    });
+    location += length;
+  }
+  tokens
+}
+
 pub fn count_lines(fragment: &str) -> usize {
   fragment.chars().into_iter().filter(|c| *c == '\n').count() + 1
 }
@@ -23,8 +39,8 @@ pub fn count_lines(fragment: &str) -> usize {
 pub fn calculate_column(fragment: &str) -> usize {
   println!("{:?} {:?}", fragment, fragment.rfind('\n'));
   match fragment.rfind('\n') {
-    Some(p) => fragment.chars().count() - p,
-    None => fragment.len() + 1
+    Some(p) => fragment.chars().count() - fragment[..p].chars().count(),
+    None => fragment.chars().count() + 1
   }
 }
 
@@ -45,10 +61,43 @@ mod tests {
 
   #[test]
   fn test_calculate_column_correctly_calculates_final_column_of_last_line() {
-    // Note: next column after last
+    // Note: next column after last, in chars
     assert_eq!(calculate_column(""), 1);
-    assert_eq!(calculate_column("test"), 5);
+    assert_eq!(calculate_column("test中"), 6);
     assert_eq!(calculate_column("test\n"), 1);
     assert_eq!(calculate_column("test\ntest2"), 6);
+    assert_eq!(calculate_column("test\ntest中2"), 7);
+    assert_eq!(calculate_column("test\ntest中2\n中3"), 3);
    }
+
+  #[test]
+  fn source_to_token_with_location_calculates_correct_locations() {
+    // Note: next column after last, in chars
+    {
+      let tokens = source_to_tokens_with_location("/* test */\n// test");
+      assert_eq!(tokens.get(0).unwrap().location, 0);
+      assert_eq!(tokens.get(1).unwrap().location, 10);
+    }
+    {
+      let tokens = source_to_tokens_with_location("/* te中st */\n\\ test");
+      assert_eq!(tokens.get(0).unwrap().location, 0);
+      assert_eq!(tokens.get(1).unwrap().location, 13);
+    }
+    {
+      let tokens = source_to_tokens_with_location("/* te中st */\n// test\nfn 中(){\t}");
+      println!("{:?}", tokens);
+      assert_eq!(tokens.get(0).unwrap().location, 0); // Block comment
+      assert_eq!(tokens.get(1).unwrap().location, 13); // Whitespace
+      assert_eq!(tokens.get(2).unwrap().location, 14); // Line comment
+      assert_eq!(tokens.get(3).unwrap().location, 21); // Whitespace
+      assert_eq!(tokens.get(4).unwrap().location, 22); // Function keyword
+      assert_eq!(tokens.get(5).unwrap().location, 24); // Whitespace
+      assert_eq!(tokens.get(6).unwrap().location, 25); // Function name
+      assert_eq!(tokens.get(7).unwrap().location, 28); // Open bracket
+      assert_eq!(tokens.get(8).unwrap().location, 29); // Close bracket
+      assert_eq!(tokens.get(9).unwrap().location, 30); // Open curly bracket
+      assert_eq!(tokens.get(10).unwrap().location, 31); // Whitespace
+      assert_eq!(tokens.get(11).unwrap().location, 32); // Close curly bracket
+    }
+  }
 }

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -247,7 +247,7 @@ fn literal_set_from_block_comment(token: &TokenWithType) -> Result<LiteralSet, S
     let mut lines = token.content.split("\n");
     if number_of_lines == 1 {
         let literal = match TrimmedLiteral::from(
-        CommentVariant::Unknown, &token.content, token.kind.pre_in_chars(),
+        CommentVariant::SlashStar, &token.content, token.kind.pre_in_chars(),
         token.kind.post_in_chars(), token.line, token.column) {
       Err(s) => return Err(format!(
           "Failed to create literal from single line block comment, content \"{}\" - caused by \"{}\"",
@@ -266,7 +266,7 @@ fn literal_set_from_block_comment(token: &TokenWithType) -> Result<LiteralSet, S
             Some(l) => l,
         };
         let literal = match TrimmedLiteral::from(
-            CommentVariant::Unknown,
+            CommentVariant::SlashStar,
             next_line,
             token.kind.pre_in_chars(),
             0,
@@ -292,7 +292,7 @@ fn literal_set_from_block_comment(token: &TokenWithType) -> Result<LiteralSet, S
                 0
             };
             let literal = match TrimmedLiteral::from(
-                CommentVariant::Unknown,
+                CommentVariant::SlashStar,
                 next_line,
                 0,
                 post,
@@ -326,7 +326,7 @@ fn literal_set_from_block_comment(token: &TokenWithType) -> Result<LiteralSet, S
 fn literal_from_line_comment(token: &TokenWithType) -> Result<TrimmedLiteral, String> {
     match token.kind {
         TokenType::LineComment => TrimmedLiteral::from(
-            CommentVariant::Unknown,
+            CommentVariant::DoubleSlash,
             &token.content,
             token.kind.pre_in_chars(),
             token.kind.post_in_chars(),

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -372,7 +372,7 @@ mod tests {
   }
 
   /// Convenience function to convert from source to tokens with line & column for tests
-  fn source_to_token_with_line_column(source: &str) -> Vec<TokenWithLineColumn> {
+  fn source_to_tokens_with_line_column(source: &str) -> Vec<TokenWithLineColumn> {
     let tokens = source_to_tokens_with_location(source);
     tokens_with_location_to_tokens_with_line_and_column(source, tokens)
   }
@@ -381,7 +381,7 @@ mod tests {
   fn test_tokens_with_line_column_values_set_correctly() {
     {
       let source = "/* test */\n// test";
-      let tokens = source_to_token_with_line_column(source);
+      let tokens = source_to_tokens_with_line_column(source);
       assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
       assert_eq!(tokens.get(0).unwrap().column, 0);
       assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
@@ -391,7 +391,7 @@ mod tests {
     }
     {
       let source = "/* te中st */\n// test";
-      let tokens = source_to_token_with_line_column(source);
+      let tokens = source_to_tokens_with_line_column(source);
       assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
       assert_eq!(tokens.get(0).unwrap().column, 0);
       assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
@@ -401,7 +401,7 @@ mod tests {
     }
     {
       let source = "/* te中st */\n// test\nfn 中(){\t}";
-      let tokens = source_to_token_with_line_column(source);
+      let tokens = source_to_tokens_with_line_column(source);
       assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
       assert_eq!(tokens.get(0).unwrap().column, 0);
       assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
@@ -544,7 +544,7 @@ mod tests {
 
   /// Convenience function to convert a source string into a set of `TokenWithType`s
   fn source_to_tokens_with_type(source: &str) -> Vec<TokenWithType> {
-    let tokens = source_to_token_with_line_column(source);
+    let tokens = source_to_tokens_with_line_column(source);
     token_with_line_column_to_token_with_type(tokens)
   }
 

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -179,15 +179,12 @@ pub fn source_to_tokens_with_location(source: &str) -> Vec<TokenWithLocation> {
 /// to calculate line & column from location.
 pub fn tokens_with_location_to_tokens_with_line_and_column
     (source: &str, tokens_in: Vec<TokenWithLocation>) -> Vec<TokenWithLineColumn> {
-  let mut tokens_out = vec!();
-  for token in tokens_in {
-    tokens_out.push(TokenWithLineColumn{
-      content: token.content,
-      line: count_lines(&source[..token.location]),
-      column: calculate_column(&source[..token.location])
-    });
-  }
-  tokens_out
+  tokens_in.into_iter()
+      .map(|t| TokenWithLineColumn {
+        content: t.content,
+        line: count_lines(&source[..t.location]),
+        column: calculate_column(&source[..t.location])
+      }).collect()
 }
 
 /// Given a string, calculates the 1 indexed line number of the line on which the final character

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -120,14 +120,12 @@ impl TokenWithType {
   /// Convert a `TokenWithLineColumn` to a `TokenWithType`. The kind is worked out from the content
   /// by checking against the developer block comment & line comment regexes.
   fn from (token: TokenWithLineColumn) -> Self {
-    let kind = {
-      if BLOCK_COMMENT.is_match(&token.content) {
-        TokenType::BlockComment
-      } else if LINE_COMMENT.is_match(&token.content) {
-        TokenType::LineComment
-      } else {
-        TokenType::Other
-      }
+    let kind = if BLOCK_COMMENT.is_match(&token.content) {
+      TokenType::BlockComment
+    } else if LINE_COMMENT.is_match(&token.content) {
+      TokenType::LineComment
+    } else {
+      TokenType::Other
     };
     Self { kind, content: token.content, line: token.line, column: token.column }
   }

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -1,4 +1,3 @@
-
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
@@ -38,192 +37,216 @@ lazy_static::lazy_static! {
 /// in 0 indexed bytes
 #[derive(Debug)]
 struct TokenWithLocation {
-  /// The full contents of this token, including pre/post characters (like '//')
-  content: String,
-  /// The location of the start of this token in the source string, in bytes
-  location: usize
+    /// The full contents of this token, including pre/post characters (like '//')
+    content: String,
+    /// The location of the start of this token in the source string, in bytes
+    location: usize,
 }
 
 /// A string token from a source string with the location at which it occurs in the source string
 /// as line on which it occurs (1 indexed) and the column of its first character (0 indexed)
 #[derive(Debug)]
 struct TokenWithLineColumn {
-  /// The full contents of this token, including pre/post characters (like '//')
-  content: String,
-  /// The first line on which the token appears in the source file (1 indexed)
-  line: usize,
-  /// The column where the first character of this token appears in the source file (0 indexed)
-  column: usize
+    /// The full contents of this token, including pre/post characters (like '//')
+    content: String,
+    /// The first line on which the token appears in the source file (1 indexed)
+    line: usize,
+    /// The column where the first character of this token appears in the source file (0 indexed)
+    column: usize,
 }
 
 /// Is a token of type (developer) block comment, (developer) line comment or something else
 #[derive(Debug, Eq, PartialEq)]
 enum TokenType {
-  BlockComment,
-  LineComment,
-  Other
+    BlockComment,
+    LineComment,
+    Other,
 }
 
 impl Display for TokenType {
-  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-    let kind = match self {
-      TokenType::BlockComment => "developer block comment",
-      TokenType::LineComment => "developer line comment",
-      TokenType::Other => "not a developer comment"
-    };
-    write!(f, "{}", kind)
-  }
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            TokenType::BlockComment => "developer block comment",
+            TokenType::LineComment => "developer line comment",
+            TokenType::Other => "not a developer comment",
+        };
+        write!(f, "{}", kind)
+    }
 }
 
 impl TokenType {
-  /// The prefix string for this type of token
-  fn pre(&self) -> &str {
-    match self {
-      TokenType::BlockComment => BLOCK_COMMENT_PREFIX,
-      TokenType::LineComment => LINE_COMMENT_PREFIX,
-      TokenType::Other => OTHER_PREFIX
+    /// The prefix string for this type of token
+    fn pre(&self) -> &str {
+        match self {
+            TokenType::BlockComment => BLOCK_COMMENT_PREFIX,
+            TokenType::LineComment => LINE_COMMENT_PREFIX,
+            TokenType::Other => OTHER_PREFIX,
+        }
     }
-  }
-  /// The postfix string for this type of token
-  fn post(&self) -> &str {
-    match self {
-      TokenType::BlockComment => BLOCK_COMMENT_POSTFIX,
-      TokenType::LineComment => LINE_COMMENT_POSTFIX,
-      TokenType::Other => OTHER_POSTFIX
+    /// The postfix string for this type of token
+    fn post(&self) -> &str {
+        match self {
+            TokenType::BlockComment => BLOCK_COMMENT_POSTFIX,
+            TokenType::LineComment => LINE_COMMENT_POSTFIX,
+            TokenType::Other => OTHER_POSTFIX,
+        }
     }
-  }
-  /// The length of the prefix for the token in characters
-  fn pre_in_chars(&self) -> usize {
-    self.pre().chars().count()
-  }
-  /// The length of the postfix for the token in characters
-  fn post_in_chars(&self) -> usize {
-    self.post().chars().count()
-  }
+    /// The length of the prefix for the token in characters
+    fn pre_in_chars(&self) -> usize {
+        self.pre().chars().count()
+    }
+    /// The length of the postfix for the token in characters
+    fn post_in_chars(&self) -> usize {
+        self.post().chars().count()
+    }
 }
 
 /// A token from a source string with its variant (TokenType) and the line and column on which it
 /// occurs according to the description for `TokenWithLineColumn`
 #[derive(Debug)]
 struct TokenWithType {
-  /// Is the token a block developer comment, line developer comment or something else
-  kind: TokenType,
-  /// The full contents of this token, including pre/post characters (like '//')
-  pub content: String,
-  /// The first line on which the token appears in the source file (1 indexed)  pub line: usize,
-  pub line: usize,
-  /// The column where the first character of this token appears in the source file (0 indexed)
-  pub column: usize,
+    /// Is the token a block developer comment, line developer comment or something else
+    kind: TokenType,
+    /// The full contents of this token, including pre/post characters (like '//')
+    pub content: String,
+    /// The first line on which the token appears in the source file (1 indexed)  pub line: usize,
+    pub line: usize,
+    /// The column where the first character of this token appears in the source file (0 indexed)
+    pub column: usize,
 }
 
 impl TokenWithType {
-  /// Convert a `TokenWithLineColumn` to a `TokenWithType`. The kind is worked out from the content
-  /// by checking against the developer block comment & line comment regexes.
-  fn from (token: TokenWithLineColumn) -> Self {
-    let kind = if BLOCK_COMMENT.is_match(&token.content) {
-      TokenType::BlockComment
-    } else if LINE_COMMENT.is_match(&token.content) {
-      TokenType::LineComment
-    } else {
-      TokenType::Other
-    };
-    Self { kind, content: token.content, line: token.line, column: token.column }
-  }
+    /// Convert a `TokenWithLineColumn` to a `TokenWithType`. The kind is worked out from the content
+    /// by checking against the developer block comment & line comment regexes.
+    fn from(token: TokenWithLineColumn) -> Self {
+        let kind = if BLOCK_COMMENT.is_match(&token.content) {
+            TokenType::BlockComment
+        } else if LINE_COMMENT.is_match(&token.content) {
+            TokenType::LineComment
+        } else {
+            TokenType::Other
+        };
+        Self {
+            kind,
+            content: token.content,
+            line: token.line,
+            column: token.column,
+        }
+    }
 }
 
 /// A convenience method that runs the complete 'pipeline' from string `source` file to all
 /// `LiteralSet`s that can be created from developer comments in the source
 pub fn extract_developer_comments(source: &str) -> Vec<LiteralSet> {
-  let tokens = source_to_tokens_with_location(source);
-  let tokens = tokens_with_location_to_tokens_with_line_and_column(source, tokens);
-  let tokens = token_with_line_column_to_token_with_type(tokens);
-  let block_comments = literal_sets_from_block_comments(tokens.iter().collect());
-  let line_comments = literal_sets_from_line_comments(tokens.iter().collect());
-  block_comments.into_iter().chain(line_comments.into_iter()).collect()
+    let tokens = source_to_tokens_with_location(source);
+    let tokens = tokens_with_location_to_tokens_with_line_and_column(source, tokens);
+    let tokens = token_with_line_column_to_token_with_type(tokens);
+    let block_comments = literal_sets_from_block_comments(tokens.iter().collect());
+    let line_comments = literal_sets_from_line_comments(tokens.iter().collect());
+    block_comments
+        .into_iter()
+        .chain(line_comments.into_iter())
+        .collect()
 }
 
 /// Creates a series of `TokenWithLocation`s from a source string
 fn source_to_tokens_with_location(source: &str) -> Vec<TokenWithLocation> {
-  let ra_tokens = tokenize(source).0;
-  let mut tokens = vec!();
-  let mut location = 0;
-  for token in ra_tokens {
-    let length = usize::from(token.len);
-    tokens.push(TokenWithLocation{
-      content: source[location..location + length].to_string(),
-      location
-    });
-    location += length;
-  }
-  tokens
+    let ra_tokens = tokenize(source).0;
+    let mut tokens = vec![];
+    let mut location = 0;
+    for token in ra_tokens {
+        let length = usize::from(token.len);
+        tokens.push(TokenWithLocation {
+            content: source[location..location + length].to_string(),
+            location,
+        });
+        location += length;
+    }
+    tokens
 }
 
 /// Converts a series of `TokenWithLocation`s to `TokenWithLineColumn`s. Requires the source string
 /// to calculate line & column from location.
-fn tokens_with_location_to_tokens_with_line_and_column
-    (source: &str, tokens_in: Vec<TokenWithLocation>) -> Vec<TokenWithLineColumn> {
-  tokens_in.into_iter()
-      .map(|t| TokenWithLineColumn {
-        content: t.content,
-        line: count_lines(&source[..t.location]),
-        column: calculate_column(&source[..t.location])
-      }).collect()
+fn tokens_with_location_to_tokens_with_line_and_column(
+    source: &str,
+    tokens_in: Vec<TokenWithLocation>,
+) -> Vec<TokenWithLineColumn> {
+    tokens_in
+        .into_iter()
+        .map(|t| TokenWithLineColumn {
+            content: t.content,
+            line: count_lines(&source[..t.location]),
+            column: calculate_column(&source[..t.location]),
+        })
+        .collect()
 }
 
 /// Given a string, calculates the 1 indexed line number of the line on which the final character
 /// of the string appears
 fn count_lines(fragment: &str) -> usize {
-  fragment.chars().into_iter().filter(|c| *c == '\n').count() + 1
+    fragment.chars().into_iter().filter(|c| *c == '\n').count() + 1
 }
 
 /// Given a string, calculates the 0 indexed column number of the character *just after* the final
 /// character in the string
 fn calculate_column(fragment: &str) -> usize {
-  match fragment.rfind('\n') {
-    Some(p) => fragment.chars().count() - fragment[..p].chars().count() - 1,
-    None => fragment.chars().count()
-  }
+    match fragment.rfind('\n') {
+        Some(p) => fragment.chars().count() - fragment[..p].chars().count() - 1,
+        None => fragment.chars().count(),
+    }
 }
 
 /// Converts a series of `TokenWithLineColumn`s to `TokenWithType`s
-fn token_with_line_column_to_token_with_type(tokens_in: Vec<TokenWithLineColumn>)
-    -> Vec<TokenWithType> {
-  tokens_in.into_iter().map(|t| TokenWithType::from(t)).collect()
+fn token_with_line_column_to_token_with_type(
+    tokens_in: Vec<TokenWithLineColumn>,
+) -> Vec<TokenWithType> {
+    tokens_in
+        .into_iter()
+        .map(|t| TokenWithType::from(t))
+        .collect()
 }
 
 /// Attempts to convert all `TokenWithType` with kind `TokenType::BlockComment` in the input into
 /// literal sets, returning those successful or otherwise logging the errors
 fn literal_sets_from_block_comments(tokens: Vec<&TokenWithType>) -> Vec<LiteralSet> {
-  let mut literal_sets = vec!();
-  let only_block_comments: Vec<&TokenWithType> =
-      tokens.into_iter().filter(|t| t.kind == TokenType::BlockComment).collect();
-  for token in only_block_comments {
-    match literal_set_from_block_comment(token) {
+    let mut literal_sets = vec![];
+    let only_block_comments: Vec<&TokenWithType> = tokens
+        .into_iter()
+        .filter(|t| t.kind == TokenType::BlockComment)
+        .collect();
+    for token in only_block_comments {
+        match literal_set_from_block_comment(token) {
       Ok(ls) => literal_sets.push(ls),
       Err(e) => log::trace!(
           "Attempted to convert block comment with content \"{}\" to literal set, failed with \"{}\"",
           token.content, e)
     }
-  }
-  literal_sets
+    }
+    literal_sets
 }
 
 /// Attempts to create a `LiteralSet` from a token assuming it is block comment. Returns `None` if
 /// the token kind is not `TokenKind::BlockComment`, if the token content does not match the
 /// block comment regex, or if any line cannot be added by `LiteralSet::add_adjacent`
 fn literal_set_from_block_comment(token: &TokenWithType) -> Result<LiteralSet, String> {
-  if token.kind != TokenType::BlockComment {
-    return Err(format!("Got token of type {}, need {}", token.kind, TokenType::BlockComment));
-  }
-  if !BLOCK_COMMENT.is_match(&token.content) {
-    return Err(format!(
-        "Token claimed to be of type {}, but improperly delimited - actual content \"{}\"",
-        TokenType::BlockComment, token.content));
-  }
-  let number_of_lines = token.content.split("\n").count();
-  let mut lines = token.content.split("\n");
-  if number_of_lines == 1 {
-    let literal = match TrimmedLiteral::from(
+    if token.kind != TokenType::BlockComment {
+        return Err(format!(
+            "Got token of type {}, need {}",
+            token.kind,
+            TokenType::BlockComment
+        ));
+    }
+    if !BLOCK_COMMENT.is_match(&token.content) {
+        return Err(format!(
+            "Token claimed to be of type {}, but improperly delimited - actual content \"{}\"",
+            TokenType::BlockComment,
+            token.content
+        ));
+    }
+    let number_of_lines = token.content.split("\n").count();
+    let mut lines = token.content.split("\n");
+    if number_of_lines == 1 {
+        let literal = match TrimmedLiteral::from(
         CommentVariant::Unknown, &token.content, token.kind.pre_in_chars(),
         token.kind.post_in_chars(), token.line, token.column) {
       Err(s) => return Err(format!(
@@ -231,571 +254,629 @@ fn literal_set_from_block_comment(token: &TokenWithType) -> Result<LiteralSet, S
           token.content, s)),
       Ok(l) => l
     };
-    Ok(LiteralSet::from(literal))
-  } else {
-    let next_line = match lines.next() {
-      None => return Err(format!(
-        "BUG! Expected block comment \"{}\" to have at least two lines", token.content)),
-      Some(l) => l
-    };
-    let literal = match TrimmedLiteral::from(
-        CommentVariant::Unknown, next_line, token.kind.pre_in_chars(), 0,
-        token.line, token.column) {
-      Err(s) => return Err(format!("Failed to create literal from block comment with content \"{}\" \
+        Ok(LiteralSet::from(literal))
+    } else {
+        let next_line = match lines.next() {
+            None => {
+                return Err(format!(
+                    "BUG! Expected block comment \"{}\" to have at least two lines",
+                    token.content
+                ))
+            }
+            Some(l) => l,
+        };
+        let literal = match TrimmedLiteral::from(
+            CommentVariant::Unknown,
+            next_line,
+            token.kind.pre_in_chars(),
+            0,
+            token.line,
+            token.column,
+        ) {
+            Err(s) => {
+                return Err(format!(
+                    "Failed to create literal from block comment with content \"{}\" \
           due to error \"{}\"",
-          next_line, s)),
-      Ok(l) => l
-    };
-    let mut literal_set = LiteralSet::from(literal);
-    let mut line_number = token.line;
-    while let Some(next_line) = lines.next() {
-      line_number += 1;
-      let post = if next_line.ends_with(BLOCK_COMMENT_POSTFIX) {
-        TokenType::BlockComment.post_in_chars()
-      } else {
-        0
-      };
-      let literal = match TrimmedLiteral::from(
-          CommentVariant::Unknown, next_line, 0, post, line_number, 0) {
-        Err(s) => return Err(format!("Failed to create literal from content \"{}\" due to error \"{}\"",
-            next_line, s)),
-        Ok(l) => l
-      };
-      match literal_set.add_adjacent(literal) {
-        Ok(_) => (),
-        Err(_) => return Err(format!("Failed to add line with content {} to literal set", next_line))
-      }
+                    next_line, s
+                ))
+            }
+            Ok(l) => l,
+        };
+        let mut literal_set = LiteralSet::from(literal);
+        let mut line_number = token.line;
+        while let Some(next_line) = lines.next() {
+            line_number += 1;
+            let post = if next_line.ends_with(BLOCK_COMMENT_POSTFIX) {
+                TokenType::BlockComment.post_in_chars()
+            } else {
+                0
+            };
+            let literal = match TrimmedLiteral::from(
+                CommentVariant::Unknown,
+                next_line,
+                0,
+                post,
+                line_number,
+                0,
+            ) {
+                Err(s) => {
+                    return Err(format!(
+                        "Failed to create literal from content \"{}\" due to error \"{}\"",
+                        next_line, s
+                    ))
+                }
+                Ok(l) => l,
+            };
+            match literal_set.add_adjacent(literal) {
+                Ok(_) => (),
+                Err(_) => {
+                    return Err(format!(
+                        "Failed to add line with content {} to literal set",
+                        next_line
+                    ))
+                }
+            }
+        }
+        Ok(literal_set)
     }
-    Ok(literal_set)
-  }
 }
 
 /// Attempt to create a literal from a developer line comment token. Returns `None` if the token's
 /// kind is not `TokenType::LineComment` or if the call to `TrimmedLiteral::from` fails.
 fn literal_from_line_comment(token: &TokenWithType) -> Result<TrimmedLiteral, String> {
-  match token.kind {
-    TokenType::LineComment => TrimmedLiteral::from(
-        CommentVariant::Unknown, &token.content, token.kind.pre_in_chars(),
-        token.kind.post_in_chars(), token.line, token.column),
-    _ => Err(format!("Expected a token of type {}, got {}", TokenType::LineComment, token.kind))
-  }
+    match token.kind {
+        TokenType::LineComment => TrimmedLiteral::from(
+            CommentVariant::Unknown,
+            &token.content,
+            token.kind.pre_in_chars(),
+            token.kind.post_in_chars(),
+            token.line,
+            token.column,
+        ),
+        _ => Err(format!(
+            "Expected a token of type {}, got {}",
+            TokenType::LineComment,
+            token.kind
+        )),
+    }
 }
 
 /// Converts a vector of tokens into a vector of `LiteralSet`s based on the developer line comments
 /// in the input, ignoring all other tokens in the input.
 fn literal_sets_from_line_comments(tokens: Vec<&TokenWithType>) -> Vec<LiteralSet> {
-  let mut sets = vec!();
-  for token in tokens {
-    if token.kind != TokenType::LineComment {
-      continue;
-    }
-    let literal = match literal_from_line_comment(token) {
-      Err(s) => {
-        log::trace!("Failed to create literal from line comment with content \"{}\" due to \"{}\"",
-            token.content, s);
-        continue;
-      },
-      Ok(l) => l
-    };
-    match sets.pop() {
-      None => sets.push(LiteralSet::from(literal)),
-      Some(mut s) => {
-        match s.add_adjacent(literal) {
-          Err(literal) => {
-            sets.push(s);
-            sets.push(LiteralSet::from(literal))
-          },
-          Ok(_) => sets.push(s)
+    let mut sets = vec![];
+    for token in tokens {
+        if token.kind != TokenType::LineComment {
+            continue;
         }
-      }
+        let literal = match literal_from_line_comment(token) {
+            Err(s) => {
+                log::trace!(
+                    "Failed to create literal from line comment with content \"{}\" due to \"{}\"",
+                    token.content,
+                    s
+                );
+                continue;
+            }
+            Ok(l) => l,
+        };
+        match sets.pop() {
+            None => sets.push(LiteralSet::from(literal)),
+            Some(mut s) => match s.add_adjacent(literal) {
+                Err(literal) => {
+                    sets.push(s);
+                    sets.push(LiteralSet::from(literal))
+                }
+                Ok(_) => sets.push(s),
+            },
+        }
     }
-  }
-  sets
+    sets
 }
 
 #[cfg(test)]
 mod tests {
-  use crate::documentation::developer::*;
+    use crate::documentation::developer::*;
 
-  #[test]
-  fn test_count_lines_correctly_counts_lines() {
-    // Note: lines are 1 indexed
-    assert_eq!(count_lines(""), 1);
-    assert_eq!(count_lines("test"), 1);
-    assert_eq!(count_lines("test\ntest"), 2);
-    assert_eq!(count_lines("test\ntest\n something else \n"), 4);
-    assert_eq!(count_lines("\n test\ntest\n something else \n"), 5);
-  }
+    #[test]
+    fn test_count_lines_correctly_counts_lines() {
+        // Note: lines are 1 indexed
+        assert_eq!(count_lines(""), 1);
+        assert_eq!(count_lines("test"), 1);
+        assert_eq!(count_lines("test\ntest"), 2);
+        assert_eq!(count_lines("test\ntest\n something else \n"), 4);
+        assert_eq!(count_lines("\n test\ntest\n something else \n"), 5);
+    }
 
-  #[test]
-  fn test_calculate_column_correctly_calculates_final_column_of_last_line() {
-    // Note: next column after last, in chars, zero indexed
-    assert_eq!(calculate_column(""), 0);
-    assert_eq!(calculate_column("test中"), 5);
-    assert_eq!(calculate_column("test\n"), 0);
-    assert_eq!(calculate_column("test\ntest2"), 5);
-    assert_eq!(calculate_column("test\ntest中2"), 6);
-    assert_eq!(calculate_column("test\ntest中2\n中3"), 2);
-  }
+    #[test]
+    fn test_calculate_column_correctly_calculates_final_column_of_last_line() {
+        // Note: next column after last, in chars, zero indexed
+        assert_eq!(calculate_column(""), 0);
+        assert_eq!(calculate_column("test中"), 5);
+        assert_eq!(calculate_column("test\n"), 0);
+        assert_eq!(calculate_column("test\ntest2"), 5);
+        assert_eq!(calculate_column("test\ntest中2"), 6);
+        assert_eq!(calculate_column("test\ntest中2\n中3"), 2);
+    }
 
-  #[test]
-  fn test_source_to_token_with_location_calculates_correct_locations() {
-    {
-      let tokens = source_to_tokens_with_location("/* test */\n// test");
-      assert_eq!(tokens.get(0).unwrap().location, 0); // Block comment
-      assert_eq!(tokens.get(1).unwrap().location, 10); // Whitespace
-      assert_eq!(tokens.get(2).unwrap().location, 11); // Line comment
-    }
-    {
-      let tokens = source_to_tokens_with_location("/* te中st */\n// test");
-      assert_eq!(tokens.get(0).unwrap().location, 0); // Block comment
-      assert_eq!(tokens.get(1).unwrap().location, 13); // Whitespace
-      assert_eq!(tokens.get(2).unwrap().location, 14); // Line comment
-    }
-    {
-      let tokens = source_to_tokens_with_location("/* te中st */\n// test\nfn 中(){\t}");
-      assert_eq!(tokens.get(0).unwrap().location, 0); // Block comment
-      assert_eq!(tokens.get(1).unwrap().location, 13); // Whitespace
-      assert_eq!(tokens.get(2).unwrap().location, 14); // Line comment
-      assert_eq!(tokens.get(3).unwrap().location, 21); // Whitespace
-      assert_eq!(tokens.get(4).unwrap().location, 22); // Function keyword
-      assert_eq!(tokens.get(5).unwrap().location, 24); // Whitespace
-      assert_eq!(tokens.get(6).unwrap().location, 25); // Function name
-      assert_eq!(tokens.get(7).unwrap().location, 28); // Open bracket
-      assert_eq!(tokens.get(8).unwrap().location, 29); // Close bracket
-      assert_eq!(tokens.get(9).unwrap().location, 30); // Open curly bracket
-      assert_eq!(tokens.get(10).unwrap().location, 31); // Whitespace
-      assert_eq!(tokens.get(11).unwrap().location, 32); // Close curly bracket
-    }
-  }
-
-  /// Convenience function to convert from source to tokens with line & column for tests
-  fn source_to_tokens_with_line_column(source: &str) -> Vec<TokenWithLineColumn> {
-    let tokens = source_to_tokens_with_location(source);
-    tokens_with_location_to_tokens_with_line_and_column(source, tokens)
-  }
-
-  #[test]
-  fn test_tokens_with_line_column_values_set_correctly() {
-    {
-      let source = "/* test */\n// test";
-      let tokens = source_to_tokens_with_line_column(source);
-      assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
-      assert_eq!(tokens.get(0).unwrap().column, 0);
-      assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
-      assert_eq!(tokens.get(1).unwrap().column, 10);
-      assert_eq!(tokens.get(2).unwrap().line, 2); // Line comment
-      assert_eq!(tokens.get(2).unwrap().column, 0);
-    }
-    {
-      let source = "/* te中st */\n// test";
-      let tokens = source_to_tokens_with_line_column(source);
-      assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
-      assert_eq!(tokens.get(0).unwrap().column, 0);
-      assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
-      assert_eq!(tokens.get(1).unwrap().column, 11);
-      assert_eq!(tokens.get(2).unwrap().line, 2); // Line comment
-      assert_eq!(tokens.get(2).unwrap().column, 0);
-    }
-    {
-      let source = "/* te中st */\n// test\nfn 中(){\t}";
-      let tokens = source_to_tokens_with_line_column(source);
-      assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
-      assert_eq!(tokens.get(0).unwrap().column, 0);
-      assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
-      assert_eq!(tokens.get(1).unwrap().column, 11);
-      assert_eq!(tokens.get(2).unwrap().line, 2); // Line comment
-      assert_eq!(tokens.get(2).unwrap().column, 0);
-      assert_eq!(tokens.get(3).unwrap().line, 2); // Whitespace
-      assert_eq!(tokens.get(3).unwrap().column, 7);
-      assert_eq!(tokens.get(4).unwrap().line, 3); // Function keyword
-      assert_eq!(tokens.get(4).unwrap().column, 0);
-      assert_eq!(tokens.get(5).unwrap().line, 3); // Whitespace
-      assert_eq!(tokens.get(5).unwrap().column, 2);
-      assert_eq!(tokens.get(6).unwrap().line, 3); // Function name
-      assert_eq!(tokens.get(6).unwrap().column, 3);
-      assert_eq!(tokens.get(7).unwrap().line, 3); // Open bracket
-      assert_eq!(tokens.get(7).unwrap().column, 4);
-      assert_eq!(tokens.get(8).unwrap().line, 3); // Close bracket
-      assert_eq!(tokens.get(8).unwrap().column, 5);
-      assert_eq!(tokens.get(9).unwrap().line, 3); // Open curly bracket
-      assert_eq!(tokens.get(9).unwrap().column, 6);
-      assert_eq!(tokens.get(10).unwrap().line, 3); // Whitespace
-      assert_eq!(tokens.get(10).unwrap().column, 7);
-      assert_eq!(tokens.get(11).unwrap().line, 3); // Close curly bracket
-      assert_eq!(tokens.get(11).unwrap().column, 8);
-    }
-  }
-
-  #[test]
-  fn test_identify_token_type_assigns_block_comment_type_to_block_comments() {
-    let block_comments = vec!(
-        TokenWithLineColumn {
-          content: "/* Block Comment */".to_string(),
-          line: 0,
-          column: 0
-        },
-        TokenWithLineColumn {
-          content: "/* Multiple Line\nBlock Comment */".to_string(),
-          line: 0,
-          column: 0
+    #[test]
+    fn test_source_to_token_with_location_calculates_correct_locations() {
+        {
+            let tokens = source_to_tokens_with_location("/* test */\n// test");
+            assert_eq!(tokens.get(0).unwrap().location, 0); // Block comment
+            assert_eq!(tokens.get(1).unwrap().location, 10); // Whitespace
+            assert_eq!(tokens.get(2).unwrap().location, 11); // Line comment
         }
-    );
-    for token in block_comments {
-      assert_eq!(TokenWithType::from(token).kind, TokenType::BlockComment);
+        {
+            let tokens = source_to_tokens_with_location("/* te中st */\n// test");
+            assert_eq!(tokens.get(0).unwrap().location, 0); // Block comment
+            assert_eq!(tokens.get(1).unwrap().location, 13); // Whitespace
+            assert_eq!(tokens.get(2).unwrap().location, 14); // Line comment
+        }
+        {
+            let tokens = source_to_tokens_with_location("/* te中st */\n// test\nfn 中(){\t}");
+            assert_eq!(tokens.get(0).unwrap().location, 0); // Block comment
+            assert_eq!(tokens.get(1).unwrap().location, 13); // Whitespace
+            assert_eq!(tokens.get(2).unwrap().location, 14); // Line comment
+            assert_eq!(tokens.get(3).unwrap().location, 21); // Whitespace
+            assert_eq!(tokens.get(4).unwrap().location, 22); // Function keyword
+            assert_eq!(tokens.get(5).unwrap().location, 24); // Whitespace
+            assert_eq!(tokens.get(6).unwrap().location, 25); // Function name
+            assert_eq!(tokens.get(7).unwrap().location, 28); // Open bracket
+            assert_eq!(tokens.get(8).unwrap().location, 29); // Close bracket
+            assert_eq!(tokens.get(9).unwrap().location, 30); // Open curly bracket
+            assert_eq!(tokens.get(10).unwrap().location, 31); // Whitespace
+            assert_eq!(tokens.get(11).unwrap().location, 32); // Close curly bracket
+        }
     }
-  }
 
-  #[test]
-  fn test_identify_token_type_assigns_line_comment_type_to_line_comments() {
-    let line_comments = vec!(
-      TokenWithLineColumn {
-        content: "// Line Comment ".to_string(),
-        line: 0,
-        column: 0
-      }
-    );
-    for token in line_comments {
-      assert_eq!(TokenWithType::from(token).kind, TokenType::LineComment);
+    /// Convenience function to convert from source to tokens with line & column for tests
+    fn source_to_tokens_with_line_column(source: &str) -> Vec<TokenWithLineColumn> {
+        let tokens = source_to_tokens_with_location(source);
+        tokens_with_location_to_tokens_with_line_and_column(source, tokens)
     }
-  }
 
-  /// Convenience function to create a single `TokenWithLineColumn` with given string content
-  /// at line 0 and column 0
-  fn token_with_line_column_at_start(content: &str) -> TokenWithLineColumn {
-    TokenWithLineColumn { content: content.to_string(), line: 0, column: 0 }
-  }
-
-  #[test]
-  fn test_identify_token_type_assigns_other_type_to_non_developer_comments() {
-    let not_developer_comments = vec!(
-      token_with_line_column_at_start("fn"),
-      token_with_line_column_at_start(" "),
-      token_with_line_column_at_start("\n"),
-      token_with_line_column_at_start("function_name"),
-      token_with_line_column_at_start("("),
-      token_with_line_column_at_start(")"),
-      token_with_line_column_at_start(";"),
-      token_with_line_column_at_start("{"),
-      token_with_line_column_at_start("}"),
-      token_with_line_column_at_start("/// Outer documentation comment"),
-      token_with_line_column_at_start("//! Inner documentation comment")
-    );
-    for token in not_developer_comments {
-      assert_eq!(TokenWithType::from(token).kind, TokenType::Other);
+    #[test]
+    fn test_tokens_with_line_column_values_set_correctly() {
+        {
+            let source = "/* test */\n// test";
+            let tokens = source_to_tokens_with_line_column(source);
+            assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
+            assert_eq!(tokens.get(0).unwrap().column, 0);
+            assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
+            assert_eq!(tokens.get(1).unwrap().column, 10);
+            assert_eq!(tokens.get(2).unwrap().line, 2); // Line comment
+            assert_eq!(tokens.get(2).unwrap().column, 0);
+        }
+        {
+            let source = "/* te中st */\n// test";
+            let tokens = source_to_tokens_with_line_column(source);
+            assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
+            assert_eq!(tokens.get(0).unwrap().column, 0);
+            assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
+            assert_eq!(tokens.get(1).unwrap().column, 11);
+            assert_eq!(tokens.get(2).unwrap().line, 2); // Line comment
+            assert_eq!(tokens.get(2).unwrap().column, 0);
+        }
+        {
+            let source = "/* te中st */\n// test\nfn 中(){\t}";
+            let tokens = source_to_tokens_with_line_column(source);
+            assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
+            assert_eq!(tokens.get(0).unwrap().column, 0);
+            assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
+            assert_eq!(tokens.get(1).unwrap().column, 11);
+            assert_eq!(tokens.get(2).unwrap().line, 2); // Line comment
+            assert_eq!(tokens.get(2).unwrap().column, 0);
+            assert_eq!(tokens.get(3).unwrap().line, 2); // Whitespace
+            assert_eq!(tokens.get(3).unwrap().column, 7);
+            assert_eq!(tokens.get(4).unwrap().line, 3); // Function keyword
+            assert_eq!(tokens.get(4).unwrap().column, 0);
+            assert_eq!(tokens.get(5).unwrap().line, 3); // Whitespace
+            assert_eq!(tokens.get(5).unwrap().column, 2);
+            assert_eq!(tokens.get(6).unwrap().line, 3); // Function name
+            assert_eq!(tokens.get(6).unwrap().column, 3);
+            assert_eq!(tokens.get(7).unwrap().line, 3); // Open bracket
+            assert_eq!(tokens.get(7).unwrap().column, 4);
+            assert_eq!(tokens.get(8).unwrap().line, 3); // Close bracket
+            assert_eq!(tokens.get(8).unwrap().column, 5);
+            assert_eq!(tokens.get(9).unwrap().line, 3); // Open curly bracket
+            assert_eq!(tokens.get(9).unwrap().column, 6);
+            assert_eq!(tokens.get(10).unwrap().line, 3); // Whitespace
+            assert_eq!(tokens.get(10).unwrap().column, 7);
+            assert_eq!(tokens.get(11).unwrap().line, 3); // Close curly bracket
+            assert_eq!(tokens.get(11).unwrap().column, 8);
+        }
     }
-  }
 
-  fn concatenate_with_line_breaks(includes: Vec<&&str>, excludes: Vec<&&str>) -> String {
-    let mut building = String::new();
-    for piece in includes {
-      building = building + piece + "\n";
+    #[test]
+    fn test_identify_token_type_assigns_block_comment_type_to_block_comments() {
+        let block_comments = vec![
+            TokenWithLineColumn {
+                content: "/* Block Comment */".to_string(),
+                line: 0,
+                column: 0,
+            },
+            TokenWithLineColumn {
+                content: "/* Multiple Line\nBlock Comment */".to_string(),
+                line: 0,
+                column: 0,
+            },
+        ];
+        for token in block_comments {
+            assert_eq!(TokenWithType::from(token).kind, TokenType::BlockComment);
+        }
     }
-    for piece in excludes {
-      building = building + piece + "\n"
+
+    #[test]
+    fn test_identify_token_type_assigns_line_comment_type_to_line_comments() {
+        let line_comments = vec![TokenWithLineColumn {
+            content: "// Line Comment ".to_string(),
+            line: 0,
+            column: 0,
+        }];
+        for token in line_comments {
+            assert_eq!(TokenWithType::from(token).kind, TokenType::LineComment);
+        }
     }
-    building
-  }
 
-  #[test]
-  fn retain_only_developer_comments_removes_non_comment_tokens() {
-    let includes = vec!("/* A block comment */", "// A line comment");
-    let excludes = vec!("fn", "func中", "(", ")", "{", "1", "+", "2", ";", "}", "\n", " ");
-    let source = concatenate_with_line_breaks(includes.iter().collect(), excludes.iter().collect());
-    let tokens = source_to_developer_comment_tokens_with_type(&source);
-    for token in tokens {
-      for content in &excludes {
-        assert_ne!(&token.content, content);
-      }
+    /// Convenience function to create a single `TokenWithLineColumn` with given string content
+    /// at line 0 and column 0
+    fn token_with_line_column_at_start(content: &str) -> TokenWithLineColumn {
+        TokenWithLineColumn {
+            content: content.to_string(),
+            line: 0,
+            column: 0,
+        }
     }
-  }
 
-  #[test]
-  fn retain_only_developer_comments_removes_documentation_comment_tokens() {
-    let includes = vec!("/* A block comment */", "// A line comment");
-    let excludes =
-        vec!("//! An inner documentation comment", "/// An outer documentation comment");
-    let source =
-      concatenate_with_line_breaks(includes.iter().collect(), excludes.iter().collect());
-    let tokens = source_to_developer_comment_tokens_with_type(&source);
-    for token in tokens {
-      for content in &excludes {
-        assert_ne!(&token.content, content);
-      }
+    #[test]
+    fn test_identify_token_type_assigns_other_type_to_non_developer_comments() {
+        let not_developer_comments = vec![
+            token_with_line_column_at_start("fn"),
+            token_with_line_column_at_start(" "),
+            token_with_line_column_at_start("\n"),
+            token_with_line_column_at_start("function_name"),
+            token_with_line_column_at_start("("),
+            token_with_line_column_at_start(")"),
+            token_with_line_column_at_start(";"),
+            token_with_line_column_at_start("{"),
+            token_with_line_column_at_start("}"),
+            token_with_line_column_at_start("/// Outer documentation comment"),
+            token_with_line_column_at_start("//! Inner documentation comment"),
+        ];
+        for token in not_developer_comments {
+            assert_eq!(TokenWithType::from(token).kind, TokenType::Other);
+        }
     }
-  }
 
-  #[test]
-  fn retain_only_developer_comments_keeps_developer_comment_tokens() {
-    let includes = vec!("/* A block comment */", "// A line comment");
-    let excludes = vec!("fn", "func中", "(", ")", "{", "1", "+", "2", ";", "}", "\n", " ");
-    let source =
-        concatenate_with_line_breaks(includes.iter().collect(), excludes.iter().collect());
-    let tokens = source_to_developer_comment_tokens_with_type(&source);
-    for content in includes {
-      let matches: Vec<&TokenWithType> = tokens.iter()
-          .filter(|t| t.content == content)
-          .collect();
-      assert!(matches.len() > 0);
+    fn concatenate_with_line_breaks(includes: Vec<&&str>, excludes: Vec<&&str>) -> String {
+        let mut building = String::new();
+        for piece in includes {
+            building = building + piece + "\n";
+        }
+        for piece in excludes {
+            building = building + piece + "\n"
+        }
+        building
     }
-  }
 
-  /// Convenience function to convert a source string into a set of `TokenWithType`s
-  fn source_to_tokens_with_type(source: &str) -> Vec<TokenWithType> {
-    let tokens = source_to_tokens_with_line_column(source);
-    token_with_line_column_to_token_with_type(tokens)
-  }
+    #[test]
+    fn retain_only_developer_comments_removes_non_comment_tokens() {
+        let includes = vec!["/* A block comment */", "// A line comment"];
+        let excludes = vec![
+            "fn", "func中", "(", ")", "{", "1", "+", "2", ";", "}", "\n", " ",
+        ];
+        let source =
+            concatenate_with_line_breaks(includes.iter().collect(), excludes.iter().collect());
+        let tokens = source_to_developer_comment_tokens_with_type(&source);
+        for token in tokens {
+            for content in &excludes {
+                assert_ne!(&token.content, content);
+            }
+        }
+    }
 
-  #[test]
-  fn test_block_comments_to_literal_sets_converter_keeps_block_comment_tokens() {
-    let source = "/* block comment */\n/*\n * multi line block comment\n */\n";
-    let tokens = source_to_tokens_with_type(source);
-    let literal_sets = literal_sets_from_block_comments(tokens.iter().collect());
-    assert_eq!(literal_sets.len(), 2);
-  }
+    #[test]
+    fn retain_only_developer_comments_removes_documentation_comment_tokens() {
+        let includes = vec!["/* A block comment */", "// A line comment"];
+        let excludes = vec![
+            "//! An inner documentation comment",
+            "/// An outer documentation comment",
+        ];
+        let source =
+            concatenate_with_line_breaks(includes.iter().collect(), excludes.iter().collect());
+        let tokens = source_to_developer_comment_tokens_with_type(&source);
+        for token in tokens {
+            for content in &excludes {
+                assert_ne!(&token.content, content);
+            }
+        }
+    }
 
-  #[test]
-  fn test_block_comments_to_literal_sets_converter_ignores_other_token_types() {
-    let source = "/// line comment\n/// outer documentation\npub fn test() -> i32 \
+    #[test]
+    fn retain_only_developer_comments_keeps_developer_comment_tokens() {
+        let includes = vec!["/* A block comment */", "// A line comment"];
+        let excludes = vec![
+            "fn", "func中", "(", ")", "{", "1", "+", "2", ";", "}", "\n", " ",
+        ];
+        let source =
+            concatenate_with_line_breaks(includes.iter().collect(), excludes.iter().collect());
+        let tokens = source_to_developer_comment_tokens_with_type(&source);
+        for content in includes {
+            let matches: Vec<&TokenWithType> =
+                tokens.iter().filter(|t| t.content == content).collect();
+            assert!(matches.len() > 0);
+        }
+    }
+
+    /// Convenience function to convert a source string into a set of `TokenWithType`s
+    fn source_to_tokens_with_type(source: &str) -> Vec<TokenWithType> {
+        let tokens = source_to_tokens_with_line_column(source);
+        token_with_line_column_to_token_with_type(tokens)
+    }
+
+    #[test]
+    fn test_block_comments_to_literal_sets_converter_keeps_block_comment_tokens() {
+        let source = "/* block comment */\n/*\n * multi line block comment\n */\n";
+        let tokens = source_to_tokens_with_type(source);
+        let literal_sets = literal_sets_from_block_comments(tokens.iter().collect());
+        assert_eq!(literal_sets.len(), 2);
+    }
+
+    #[test]
+    fn test_block_comments_to_literal_sets_converter_ignores_other_token_types() {
+        let source = "/// line comment\n/// outer documentation\npub fn test() -> i32 \
         {\n  //! inner documentation\n  1 + 2\n}";
-    let tokens = source_to_tokens_with_type(source);
-    let literal_sets = literal_sets_from_block_comments(tokens.iter().collect());
-    assert_eq!(literal_sets.len(), 0);
-  }
-
-  #[test]
-  fn test_single_line_block_comment_literal_correctly_created() {
-    let source = "/* block 种 comment */";
-    let tokens = source_to_tokens_with_type(source);
-    assert_eq!(tokens.len(), 1);
-    let token = tokens.into_iter().last().unwrap();
-    let literal_set = literal_set_from_block_comment(&token);
-    assert!(literal_set.is_ok());
-    let literal_set = literal_set.unwrap();
-    assert_eq!(literal_set.len(), 1);
-    let literal = literal_set.literals().into_iter().last().unwrap();
-    assert_eq!(literal.pre(), TokenType::BlockComment.pre_in_chars());
-    assert_eq!(literal.post(), TokenType::BlockComment.post_in_chars());
-    assert_eq!(literal.len_in_chars(), source.chars().count() - 4);
-    assert_eq!(literal.len(), source.len() - 4);
-    let span = &literal.span();
-    assert_eq!(span.start.line, 1);
-    assert_eq!(span.start.column, 2);
-    assert_eq!(span.end.line, 1);
-    assert_eq!(span.end.column, source.chars().count() - 2 - 1);
-  }
-
-  #[test]
-  fn test_single_line_indented_block_comment_literal_correctly_created() {
-    let source = "    /* block 种 comment */";
-    let tokens = source_to_tokens_with_type(source);
-    assert!(tokens.len() > 0);
-    let token = tokens.into_iter().last().unwrap();
-    let literal_set = literal_set_from_block_comment(&token);
-    assert!(literal_set.is_ok());
-    let literal_set = literal_set.unwrap();
-    assert_eq!(literal_set.len(), 1);
-    let literal = literal_set.literals().into_iter().last().unwrap();
-    let indent_size = "    ".len(); // Also chars, because ASCII
-    assert_eq!(literal.pre(), TokenType::BlockComment.pre_in_chars());
-    assert_eq!(literal.post(), TokenType::BlockComment.post_in_chars());
-    assert_eq!(literal.len_in_chars(), source.chars().count() - indent_size - 4);
-    assert_eq!(literal.len(), source.len() - indent_size - 4);
-    let span = &literal.span();
-    assert_eq!(span.start.line, 1);
-    assert_eq!(span.start.column, indent_size + 2);
-    assert_eq!(span.end.line, 1);
-    assert_eq!(span.end.column, source.chars().count() - 2 - 1);
-  }
-
-  #[test]
-  fn test_multi_line_block_comment_literal_correctly_created() {
-    let source = "/* block\n 种 \ncomment */";
-    let tokens = source_to_tokens_with_type(source);
-    assert_eq!(tokens.len(), 1);
-    let token = tokens.into_iter().last().unwrap();
-    let literal_set = literal_set_from_block_comment(&token);
-    assert!(literal_set.is_ok());
-    let literal_set = literal_set.unwrap();
-    assert_eq!(literal_set.len(), 3);
-    let literals = literal_set.literals();
-    {
-      let literal = literals.get(0).unwrap();
-      assert_eq!(literal.pre(), TokenType::BlockComment.pre_in_chars());
-      assert_eq!(literal.post(), "".chars().count());
-      assert_eq!(literal.len_in_chars(), " block".chars().count());
-      assert_eq!(literal.len(), " block".len());
-      let span = &literal.span();
-      assert_eq!(span.start.line, 1);
-      assert_eq!(span.start.column, 2);
-      assert_eq!(span.end.line, 1);
-      assert_eq!(span.end.column, "/* block".chars().count() - 1);
+        let tokens = source_to_tokens_with_type(source);
+        let literal_sets = literal_sets_from_block_comments(tokens.iter().collect());
+        assert_eq!(literal_sets.len(), 0);
     }
-    {
-      let literal = literals.get(1).unwrap();
-      assert_eq!(literal.pre(), "".chars().count());
-      assert_eq!(literal.post(), "".chars().count());
-      assert_eq!(literal.len_in_chars(), " 种 ".chars().count());
-      assert_eq!(literal.len(), " 种 ".len());
-      let span = &literal.span();
-      assert_eq!(span.start.line, 2);
-      assert_eq!(span.start.column, 0);
-      assert_eq!(span.end.line, 2);
-      assert_eq!(span.end.column, " 种 ".chars().count() - 1);
-    }
-    {
-      let literal = literals.get(2).unwrap();
-      assert_eq!(literal.pre(), "".chars().count());
-      assert_eq!(literal.post(), TokenType::BlockComment.post_in_chars());
-      assert_eq!(literal.len_in_chars(), "comment ".chars().count());
-      assert_eq!(literal.len(), "comment ".len());
-      let span = &literal.span();
-      assert_eq!(span.start.line, 3);
-      assert_eq!(span.start.column, 0);
-      assert_eq!(span.end.line, 3);
-      assert_eq!(span.end.column, "comment ".chars().count() - 1);
-    }
-  }
 
-  #[test]
-  fn test_not_developer_comments_block_comment_converter_does_not_create_literals() {
-    let source = "// line comment\n/// Outer documentation\nfn test(){\n \
+    #[test]
+    fn test_single_line_block_comment_literal_correctly_created() {
+        let source = "/* block 种 comment */";
+        let tokens = source_to_tokens_with_type(source);
+        assert_eq!(tokens.len(), 1);
+        let token = tokens.into_iter().last().unwrap();
+        let literal_set = literal_set_from_block_comment(&token);
+        assert!(literal_set.is_ok());
+        let literal_set = literal_set.unwrap();
+        assert_eq!(literal_set.len(), 1);
+        let literal = literal_set.literals().into_iter().last().unwrap();
+        assert_eq!(literal.pre(), TokenType::BlockComment.pre_in_chars());
+        assert_eq!(literal.post(), TokenType::BlockComment.post_in_chars());
+        assert_eq!(literal.len_in_chars(), source.chars().count() - 4);
+        assert_eq!(literal.len(), source.len() - 4);
+        let span = &literal.span();
+        assert_eq!(span.start.line, 1);
+        assert_eq!(span.start.column, 2);
+        assert_eq!(span.end.line, 1);
+        assert_eq!(span.end.column, source.chars().count() - 2 - 1);
+    }
+
+    #[test]
+    fn test_single_line_indented_block_comment_literal_correctly_created() {
+        let source = "    /* block 种 comment */";
+        let tokens = source_to_tokens_with_type(source);
+        assert!(tokens.len() > 0);
+        let token = tokens.into_iter().last().unwrap();
+        let literal_set = literal_set_from_block_comment(&token);
+        assert!(literal_set.is_ok());
+        let literal_set = literal_set.unwrap();
+        assert_eq!(literal_set.len(), 1);
+        let literal = literal_set.literals().into_iter().last().unwrap();
+        let indent_size = "    ".len(); // Also chars, because ASCII
+        assert_eq!(literal.pre(), TokenType::BlockComment.pre_in_chars());
+        assert_eq!(literal.post(), TokenType::BlockComment.post_in_chars());
+        assert_eq!(
+            literal.len_in_chars(),
+            source.chars().count() - indent_size - 4
+        );
+        assert_eq!(literal.len(), source.len() - indent_size - 4);
+        let span = &literal.span();
+        assert_eq!(span.start.line, 1);
+        assert_eq!(span.start.column, indent_size + 2);
+        assert_eq!(span.end.line, 1);
+        assert_eq!(span.end.column, source.chars().count() - 2 - 1);
+    }
+
+    #[test]
+    fn test_multi_line_block_comment_literal_correctly_created() {
+        let source = "/* block\n 种 \ncomment */";
+        let tokens = source_to_tokens_with_type(source);
+        assert_eq!(tokens.len(), 1);
+        let token = tokens.into_iter().last().unwrap();
+        let literal_set = literal_set_from_block_comment(&token);
+        assert!(literal_set.is_ok());
+        let literal_set = literal_set.unwrap();
+        assert_eq!(literal_set.len(), 3);
+        let literals = literal_set.literals();
+        {
+            let literal = literals.get(0).unwrap();
+            assert_eq!(literal.pre(), TokenType::BlockComment.pre_in_chars());
+            assert_eq!(literal.post(), "".chars().count());
+            assert_eq!(literal.len_in_chars(), " block".chars().count());
+            assert_eq!(literal.len(), " block".len());
+            let span = &literal.span();
+            assert_eq!(span.start.line, 1);
+            assert_eq!(span.start.column, 2);
+            assert_eq!(span.end.line, 1);
+            assert_eq!(span.end.column, "/* block".chars().count() - 1);
+        }
+        {
+            let literal = literals.get(1).unwrap();
+            assert_eq!(literal.pre(), "".chars().count());
+            assert_eq!(literal.post(), "".chars().count());
+            assert_eq!(literal.len_in_chars(), " 种 ".chars().count());
+            assert_eq!(literal.len(), " 种 ".len());
+            let span = &literal.span();
+            assert_eq!(span.start.line, 2);
+            assert_eq!(span.start.column, 0);
+            assert_eq!(span.end.line, 2);
+            assert_eq!(span.end.column, " 种 ".chars().count() - 1);
+        }
+        {
+            let literal = literals.get(2).unwrap();
+            assert_eq!(literal.pre(), "".chars().count());
+            assert_eq!(literal.post(), TokenType::BlockComment.post_in_chars());
+            assert_eq!(literal.len_in_chars(), "comment ".chars().count());
+            assert_eq!(literal.len(), "comment ".len());
+            let span = &literal.span();
+            assert_eq!(span.start.line, 3);
+            assert_eq!(span.start.column, 0);
+            assert_eq!(span.end.line, 3);
+            assert_eq!(span.end.column, "comment ".chars().count() - 1);
+        }
+    }
+
+    #[test]
+    fn test_not_developer_comments_block_comment_converter_does_not_create_literals() {
+        let source = "// line comment\n/// Outer documentation\nfn test(){\n \
         //! Inner documentation\n\tlet i = 1 + 2;\n}";
-    let tokens = source_to_tokens_with_type(source);
-    for token in tokens {
-      assert!(literal_set_from_block_comment(&token).is_err());
+        let tokens = source_to_tokens_with_type(source);
+        for token in tokens {
+            assert!(literal_set_from_block_comment(&token).is_err());
+        }
     }
-  }
 
-  #[test]
-  fn test_non_line_comment_tokens_line_comment_to_literal_does_not_create_literals() {
-    let source = "/* Block comment */\nfn test(i: usize) {\n  let j = 1 + i;\n  j\n}";
-    let tokens = source_to_tokens_with_type(source);
-    for token in tokens {
-      assert!(literal_from_line_comment(&token).is_err());
+    #[test]
+    fn test_non_line_comment_tokens_line_comment_to_literal_does_not_create_literals() {
+        let source = "/* Block comment */\nfn test(i: usize) {\n  let j = 1 + i;\n  j\n}";
+        let tokens = source_to_tokens_with_type(source);
+        for token in tokens {
+            assert!(literal_from_line_comment(&token).is_err());
+        }
     }
-  }
 
-  #[test]
-  fn test_documentation_line_comment_tokens_line_comment_to_literal_does_not_create_literals() {
-    let source = "/// Outer \nfn(){\n//! Inner \n}";
-    let tokens = source_to_tokens_with_type(source);
-    for token in tokens {
-      assert!(literal_from_line_comment(&token).is_err());
+    #[test]
+    fn test_documentation_line_comment_tokens_line_comment_to_literal_does_not_create_literals() {
+        let source = "/// Outer \nfn(){\n//! Inner \n}";
+        let tokens = source_to_tokens_with_type(source);
+        for token in tokens {
+            assert!(literal_from_line_comment(&token).is_err());
+        }
     }
-  }
 
-  /// Convenience method that returns a vector containing only the tokens from the input vector
-  /// which are developer comments
-  fn retain_only_developer_comments(tokens: Vec<TokenWithType>) -> Vec<TokenWithType> {
-    tokens.into_iter()
-      .filter(|t| t.kind != TokenType::Other)
-      .collect()
-  }
+    /// Convenience method that returns a vector containing only the tokens from the input vector
+    /// which are developer comments
+    fn retain_only_developer_comments(tokens: Vec<TokenWithType>) -> Vec<TokenWithType> {
+        tokens
+            .into_iter()
+            .filter(|t| t.kind != TokenType::Other)
+            .collect()
+    }
 
-  #[test]
-  fn test_developer_line_comment_tokens_line_comment_to_literal_create_literals_with_correct_data() {
-    let source = "// First line comment\nconst ZERO: usize = 0; // A constant ";
-    let tokens = source_to_tokens_with_type(source);
-    let filtered = retain_only_developer_comments(tokens);
-    assert_eq!(filtered.len(), 2);
-    let literals: Vec<Result<TrimmedLiteral, String>> = filtered.into_iter()
-      .map(|t| literal_from_line_comment(&t))
-      .collect();
-    {
-      let literal = literals.get(0).unwrap();
-      assert!(literal.is_ok());
-      let literal = literal.as_ref().unwrap();
-      assert_eq!(literal.pre(), TokenType::LineComment.pre_in_chars());
-      assert_eq!(literal.post(), TokenType::LineComment.post_in_chars());
-      assert_eq!(literal.len_in_chars(), " First line comment".chars().count());
-      assert_eq!(literal.len(), " First line comment".len());
-      let span = &literal.span();
-      assert_eq!(span.start.line, 1);
-      assert_eq!(span.start.column, 2);
-      assert_eq!(span.end.line, 1);
-      assert_eq!(span.end.column, 2 + " First line comment".chars().count() - 1);
+    #[test]
+    fn test_developer_line_comment_tokens_line_comment_to_literal_create_literals_with_correct_data(
+    ) {
+        let source = "// First line comment\nconst ZERO: usize = 0; // A constant ";
+        let tokens = source_to_tokens_with_type(source);
+        let filtered = retain_only_developer_comments(tokens);
+        assert_eq!(filtered.len(), 2);
+        let literals: Vec<Result<TrimmedLiteral, String>> = filtered
+            .into_iter()
+            .map(|t| literal_from_line_comment(&t))
+            .collect();
+        {
+            let literal = literals.get(0).unwrap();
+            assert!(literal.is_ok());
+            let literal = literal.as_ref().unwrap();
+            assert_eq!(literal.pre(), TokenType::LineComment.pre_in_chars());
+            assert_eq!(literal.post(), TokenType::LineComment.post_in_chars());
+            assert_eq!(
+                literal.len_in_chars(),
+                " First line comment".chars().count()
+            );
+            assert_eq!(literal.len(), " First line comment".len());
+            let span = &literal.span();
+            assert_eq!(span.start.line, 1);
+            assert_eq!(span.start.column, 2);
+            assert_eq!(span.end.line, 1);
+            assert_eq!(
+                span.end.column,
+                2 + " First line comment".chars().count() - 1
+            );
+        }
+        {
+            let literal = literals.get(1).unwrap();
+            assert!(literal.is_ok());
+            let literal = literal.as_ref().unwrap();
+            assert_eq!(literal.pre(), TokenType::LineComment.pre_in_chars());
+            assert_eq!(literal.post(), TokenType::LineComment.post_in_chars());
+            assert_eq!(literal.len_in_chars(), " A constant ".chars().count());
+            assert_eq!(literal.len(), " A constant ".len());
+            let span = &literal.span();
+            assert_eq!(span.start.line, 2);
+            assert_eq!(span.start.column, 25);
+            assert_eq!(span.end.line, 2);
+            assert_eq!(span.end.column, 25 + " A constant ".chars().count() - 1);
+        }
     }
-    {
-      let literal = literals.get(1).unwrap();
-      assert!(literal.is_ok());
-      let literal = literal.as_ref().unwrap();
-      assert_eq!(literal.pre(), TokenType::LineComment.pre_in_chars());
-      assert_eq!(literal.post(), TokenType::LineComment.post_in_chars());
-      assert_eq!(literal.len_in_chars(), " A constant ".chars().count());
-      assert_eq!(literal.len(), " A constant ".len());
-      let span = &literal.span();
-      assert_eq!(span.start.line, 2);
-      assert_eq!(span.start.column, 25);
-      assert_eq!(span.end.line, 2);
-      assert_eq!(span.end.column, 25 + " A constant ".chars().count() - 1);
-    }
-  }
 
-  /// A convenience method to convert a source string into a set of `TokenWithType`s and filter
-  /// out any tokens which are not developer comments
-  fn source_to_developer_comment_tokens_with_type(source: &str) -> Vec<TokenWithType> {
-    let tokens = source_to_tokens_with_type(source);
-    retain_only_developer_comments(tokens)
-  }
+    /// A convenience method to convert a source string into a set of `TokenWithType`s and filter
+    /// out any tokens which are not developer comments
+    fn source_to_developer_comment_tokens_with_type(source: &str) -> Vec<TokenWithType> {
+        let tokens = source_to_tokens_with_type(source);
+        retain_only_developer_comments(tokens)
+    }
 
-  #[test]
-  fn test_single_line_comment_put_in_one_literal_set() {
-    let content = " line comment";
-    let source = format!("//{}", content);
-    let tokens = source_to_developer_comment_tokens_with_type(&source);
-    let literal_sets = literal_sets_from_line_comments(tokens.iter().collect());
-    assert_eq!(literal_sets.len(), 1);
-    let literal_set = literal_sets.get(0).unwrap();
-    let all_literals = literal_set.literals();
-    let literal = all_literals.get(0);
-    assert!(literal.is_some());
-    let literal = literal.unwrap();
-    assert!(literal.as_str().contains(content));
-  }
+    #[test]
+    fn test_single_line_comment_put_in_one_literal_set() {
+        let content = " line comment";
+        let source = format!("//{}", content);
+        let tokens = source_to_developer_comment_tokens_with_type(&source);
+        let literal_sets = literal_sets_from_line_comments(tokens.iter().collect());
+        assert_eq!(literal_sets.len(), 1);
+        let literal_set = literal_sets.get(0).unwrap();
+        let all_literals = literal_set.literals();
+        let literal = all_literals.get(0);
+        assert!(literal.is_some());
+        let literal = literal.unwrap();
+        assert!(literal.as_str().contains(content));
+    }
 
-  #[test]
-  fn test_adjacent_line_comments_put_in_same_literal_set() {
-    let content_1 = " line comment 1 ";
-    let content_2 = " line comment 2 ";
-    let source = format!("//{}\n//{}", content_1, content_2);
-    let tokens = source_to_developer_comment_tokens_with_type(&source);
-    let literal_sets = literal_sets_from_line_comments(tokens.iter().collect());
-    assert_eq!(literal_sets.len(), 1);
-    let literal_set = literal_sets.get(0).unwrap();
-    let all_literals = literal_set.literals();
-    assert_eq!(all_literals.len(), 2);
-    {
-      let literal = all_literals.get(0).unwrap();
-      assert!(literal.as_str().contains(content_1));
+    #[test]
+    fn test_adjacent_line_comments_put_in_same_literal_set() {
+        let content_1 = " line comment 1 ";
+        let content_2 = " line comment 2 ";
+        let source = format!("//{}\n//{}", content_1, content_2);
+        let tokens = source_to_developer_comment_tokens_with_type(&source);
+        let literal_sets = literal_sets_from_line_comments(tokens.iter().collect());
+        assert_eq!(literal_sets.len(), 1);
+        let literal_set = literal_sets.get(0).unwrap();
+        let all_literals = literal_set.literals();
+        assert_eq!(all_literals.len(), 2);
+        {
+            let literal = all_literals.get(0).unwrap();
+            assert!(literal.as_str().contains(content_1));
+        }
+        {
+            let literal = all_literals.get(1).unwrap();
+            assert!(literal.as_str().contains(content_2));
+        }
     }
-    {
-      let literal = all_literals.get(1).unwrap();
-      assert!(literal.as_str().contains(content_2));
-    }
-  }
 
-  #[test]
-  fn test_non_adjacent_line_comments_put_in_different_literal_sets() {
-    let content_1 = " line comment 1 ";
-    let content_2 = " line comment 2 ";
-    let source = format!("//{}\nfn(){{}}\n//{}", content_1, content_2);
-    let tokens = source_to_developer_comment_tokens_with_type(&source);
-    let literal_sets = literal_sets_from_line_comments(tokens.iter().collect());
-    assert_eq!(literal_sets.len(), 2);
-    {
-      let literal_set = literal_sets.get(0).unwrap();
-      let all_literals = literal_set.literals();
-      assert_eq!(all_literals.len(), 1);
-      let literal = all_literals.get(0).unwrap();
-      assert!(literal.as_str().contains(content_1));
+    #[test]
+    fn test_non_adjacent_line_comments_put_in_different_literal_sets() {
+        let content_1 = " line comment 1 ";
+        let content_2 = " line comment 2 ";
+        let source = format!("//{}\nfn(){{}}\n//{}", content_1, content_2);
+        let tokens = source_to_developer_comment_tokens_with_type(&source);
+        let literal_sets = literal_sets_from_line_comments(tokens.iter().collect());
+        assert_eq!(literal_sets.len(), 2);
+        {
+            let literal_set = literal_sets.get(0).unwrap();
+            let all_literals = literal_set.literals();
+            assert_eq!(all_literals.len(), 1);
+            let literal = all_literals.get(0).unwrap();
+            assert!(literal.as_str().contains(content_1));
+        }
+        {
+            let literal_set = literal_sets.get(1).unwrap();
+            let all_literals = literal_set.literals();
+            assert_eq!(all_literals.len(), 1);
+            let literal = all_literals.get(0).unwrap();
+            assert!(literal.as_str().contains(content_2));
+        }
     }
-    {
-      let literal_set = literal_sets.get(1).unwrap();
-      let all_literals = literal_set.literals();
-      assert_eq!(all_literals.len(), 1);
-      let literal = all_literals.get(0).unwrap();
-      assert!(literal.as_str().contains(content_2));
-    }
-  }
 }

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -627,6 +627,27 @@ mod tests {
   }
 
   #[test]
+  fn test_block_comments_to_literal_sets_converter_keeps_block_comment_tokens() {
+    let source = "/* block comment */\n/*\n * multi line block comment\n */\n";
+    let tokens = source_to_tokens_with_location(&source);
+    let tokens = tokens_with_location_to_tokens_with_line_and_column(&source, tokens);
+    let tokens = token_with_line_column_to_token_with_type(tokens);
+    let literal_sets = literal_sets_from_block_comments(tokens.iter().collect());
+    assert_eq!(literal_sets.len(), 2);
+  }
+
+  #[test]
+  fn test_block_comments_to_literal_sets_converter_ignores_other_token_types() {
+    let source = "/// line comment\n/// outer documentation\npub fn test() -> i32 \
+        {\n  //! inner documentation\n  1 + 2\n}";
+    let tokens = source_to_tokens_with_location(&source);
+    let tokens = tokens_with_location_to_tokens_with_line_and_column(&source, tokens);
+    let tokens = token_with_line_column_to_token_with_type(tokens);
+    let literal_sets = literal_sets_from_block_comments(tokens.iter().collect());
+    assert_eq!(literal_sets.len(), 0);
+  }
+
+  #[test]
   fn test_single_line_block_comment_literal_correctly_created() {
     let source = "/* block 种 comment */";
     let tokens = source_to_tokens_with_location(source);

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -7,13 +7,15 @@ use super::*;
 #[derive(Debug)]
 pub struct TokenWithLocation {
   content: String,
+  // Bytes
   location: usize
 }
 
 #[derive(Debug)]
-struct TokenWithLineColumn {
+pub struct TokenWithLineColumn {
   content: String,
   line: usize,
+  // Characters
   column: usize
 }
 
@@ -32,14 +34,27 @@ pub fn source_to_tokens_with_location(source: &str) -> Vec<TokenWithLocation> {
   tokens
 }
 
+pub fn tokens_with_location_to_tokens_with_line_and_column
+(source: &str, tokens_in: Vec<TokenWithLocation>) -> Vec<TokenWithLineColumn> {
+  let mut tokens_out = vec!();
+  for token in tokens_in {
+    tokens_out.push(TokenWithLineColumn{
+      content: token.content,
+      line: count_lines(&source[..token.location]),
+      column: calculate_column(&source[..token.location])
+    });
+  }
+  tokens_out
+}
+
 pub fn count_lines(fragment: &str) -> usize {
   fragment.chars().into_iter().filter(|c| *c == '\n').count() + 1
 }
 
 pub fn calculate_column(fragment: &str) -> usize {
   match fragment.rfind('\n') {
-    Some(p) => fragment.chars().count() - fragment[..p].chars().count(),
-    None => fragment.chars().count() + 1
+    Some(p) => fragment.chars().count() - fragment[..p].chars().count() - 1,
+    None => fragment.chars().count()
   }
 }
 
@@ -60,31 +75,31 @@ mod tests {
 
   #[test]
   fn test_calculate_column_correctly_calculates_final_column_of_last_line() {
-    // Note: next column after last, in chars
-    assert_eq!(calculate_column(""), 1);
-    assert_eq!(calculate_column("test中"), 6);
-    assert_eq!(calculate_column("test\n"), 1);
-    assert_eq!(calculate_column("test\ntest2"), 6);
-    assert_eq!(calculate_column("test\ntest中2"), 7);
-    assert_eq!(calculate_column("test\ntest中2\n中3"), 3);
-   }
+    // Note: next column after last, in chars, zero indexed
+    assert_eq!(calculate_column(""), 0);
+    assert_eq!(calculate_column("test中"), 5);
+    assert_eq!(calculate_column("test\n"), 0);
+    assert_eq!(calculate_column("test\ntest2"), 5);
+    assert_eq!(calculate_column("test\ntest中2"), 6);
+    assert_eq!(calculate_column("test\ntest中2\n中3"), 2);
+  }
 
   #[test]
-  fn source_to_token_with_location_calculates_correct_locations() {
-    // Note: next column after last, in chars
+  fn test_source_to_token_with_location_calculates_correct_locations() {
     {
       let tokens = source_to_tokens_with_location("/* test */\n// test");
-      assert_eq!(tokens.get(0).unwrap().location, 0);
-      assert_eq!(tokens.get(1).unwrap().location, 10);
+      assert_eq!(tokens.get(0).unwrap().location, 0); // Block comment
+      assert_eq!(tokens.get(1).unwrap().location, 10); // Whitespace
+      assert_eq!(tokens.get(2).unwrap().location, 11); // Line comment
     }
     {
-      let tokens = source_to_tokens_with_location("/* te中st */\n\\ test");
-      assert_eq!(tokens.get(0).unwrap().location, 0);
-      assert_eq!(tokens.get(1).unwrap().location, 13);
+      let tokens = source_to_tokens_with_location("/* te中st */\n// test");
+      assert_eq!(tokens.get(0).unwrap().location, 0); // Block comment
+      assert_eq!(tokens.get(1).unwrap().location, 13); // Whitespace
+      assert_eq!(tokens.get(2).unwrap().location, 14); // Line comment
     }
     {
       let tokens = source_to_tokens_with_location("/* te中st */\n// test\nfn 中(){\t}");
-      println!("{:?}", tokens);
       assert_eq!(tokens.get(0).unwrap().location, 0); // Block comment
       assert_eq!(tokens.get(1).unwrap().location, 13); // Whitespace
       assert_eq!(tokens.get(2).unwrap().location, 14); // Line comment
@@ -97,6 +112,64 @@ mod tests {
       assert_eq!(tokens.get(9).unwrap().location, 30); // Open curly bracket
       assert_eq!(tokens.get(10).unwrap().location, 31); // Whitespace
       assert_eq!(tokens.get(11).unwrap().location, 32); // Close curly bracket
+    }
+  }
+
+  #[test]
+  fn test_tokens_with_line_column_values_set_correctly() {
+    {
+      let source = "/* test */\n// test";
+      let tokens = source_to_tokens_with_location(source);
+      let tokens = tokens_with_location_to_tokens_with_line_and_column(
+        source, tokens);
+      assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
+      assert_eq!(tokens.get(0).unwrap().column, 0);
+      assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
+      assert_eq!(tokens.get(1).unwrap().column, 10);
+      assert_eq!(tokens.get(2).unwrap().line, 2); // Line comment
+      assert_eq!(tokens.get(2).unwrap().column, 0);
+    }
+    {
+      let source = "/* te中st */\n// test";
+      let tokens = source_to_tokens_with_location(source);
+      let tokens = tokens_with_location_to_tokens_with_line_and_column(
+        source, tokens);
+      assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
+      assert_eq!(tokens.get(0).unwrap().column, 0);
+      assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
+      assert_eq!(tokens.get(1).unwrap().column, 11);
+      assert_eq!(tokens.get(2).unwrap().line, 2); // Line comment
+      assert_eq!(tokens.get(2).unwrap().column, 0);
+    }
+    {
+      let source = "/* te中st */\n// test\nfn 中(){\t}";
+      let tokens = source_to_tokens_with_location(source);
+      let tokens = tokens_with_location_to_tokens_with_line_and_column(
+        source, tokens);
+      assert_eq!(tokens.get(0).unwrap().line, 1); // Block comment
+      assert_eq!(tokens.get(0).unwrap().column, 0);
+      assert_eq!(tokens.get(1).unwrap().line, 1); // Whitespace
+      assert_eq!(tokens.get(1).unwrap().column, 11);
+      assert_eq!(tokens.get(2).unwrap().line, 2); // Line comment
+      assert_eq!(tokens.get(2).unwrap().column, 0);
+      assert_eq!(tokens.get(3).unwrap().line, 2); // Whitespace
+      assert_eq!(tokens.get(3).unwrap().column, 7);
+      assert_eq!(tokens.get(4).unwrap().line, 3); // Function keyword
+      assert_eq!(tokens.get(4).unwrap().column, 0);
+      assert_eq!(tokens.get(5).unwrap().line, 3); // Whitespace
+      assert_eq!(tokens.get(5).unwrap().column, 2);
+      assert_eq!(tokens.get(6).unwrap().line, 3); // Function name
+      assert_eq!(tokens.get(6).unwrap().column, 3);
+      assert_eq!(tokens.get(7).unwrap().line, 3); // Open bracket
+      assert_eq!(tokens.get(7).unwrap().column, 4);
+      assert_eq!(tokens.get(8).unwrap().line, 3); // Close bracket
+      assert_eq!(tokens.get(8).unwrap().column, 5);
+      assert_eq!(tokens.get(9).unwrap().line, 3); // Open curly bracket
+      assert_eq!(tokens.get(9).unwrap().column, 6);
+      assert_eq!(tokens.get(10).unwrap().line, 3); // Whitespace
+      assert_eq!(tokens.get(10).unwrap().column, 7);
+      assert_eq!(tokens.get(11).unwrap().line, 3); // Close curly bracket
+      assert_eq!(tokens.get(11).unwrap().column, 8);
     }
   }
 }

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -1,0 +1,54 @@
+
+use ra_ap_syntax::{SyntaxNode, SourceFile, tokenize, Token};
+use regex::Regex;
+
+use super::*;
+
+struct TokenWithLocation {
+  content: String,
+  location: usize
+}
+
+#[derive(Debug)]
+struct TokenWithLineColumn {
+  content: String,
+  line: usize,
+  column: usize
+}
+
+pub fn count_lines(fragment: &str) -> usize {
+  fragment.chars().into_iter().filter(|c| *c == '\n').count() + 1
+}
+
+pub fn calculate_column(fragment: &str) -> usize {
+  println!("{:?} {:?}", fragment, fragment.rfind('\n'));
+  match fragment.rfind('\n') {
+    Some(p) => fragment.chars().count() - p,
+    None => fragment.len() + 1
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::documentation::developer::*;
+  use ra_ap_syntax::tokenize;
+
+  #[test]
+  fn test_count_lines_correctly_counts_lines() {
+    // Note: lines are 1 indexed
+    assert_eq!(count_lines(""), 1);
+    assert_eq!(count_lines("test"), 1);
+    assert_eq!(count_lines("test\ntest"), 2);
+    assert_eq!(count_lines("test\ntest\n something else \n"), 4);
+    assert_eq!(count_lines("\n test\ntest\n something else \n"), 5);
+  }
+
+  #[test]
+  fn test_calculate_column_correctly_calculates_final_column_of_last_line() {
+    // Note: next column after last
+    assert_eq!(calculate_column(""), 1);
+    assert_eq!(calculate_column("test"), 5);
+    assert_eq!(calculate_column("test\n"), 1);
+    assert_eq!(calculate_column("test\ntest2"), 6);
+   }
+}

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -61,7 +61,6 @@ pub fn calculate_column(fragment: &str) -> usize {
 #[cfg(test)]
 mod tests {
   use crate::documentation::developer::*;
-  use ra_ap_syntax::tokenize;
 
   #[test]
   fn test_count_lines_correctly_counts_lines() {

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -311,7 +311,10 @@ fn literal_sets_from_line_comments(tokens: Vec<&TokenWithType>) -> Vec<LiteralSe
       None => sets.push(LiteralSet::from(literal)),
       Some(mut s) => {
         match s.add_adjacent(literal) {
-          Err(literal) => sets.push(LiteralSet::from(literal)),
+          Err(literal) => {
+            sets.push(s);
+            sets.push(LiteralSet::from(literal))
+          },
           Ok(_) => sets.push(s)
         }
       }

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -37,7 +37,6 @@ pub fn count_lines(fragment: &str) -> usize {
 }
 
 pub fn calculate_column(fragment: &str) -> usize {
-  println!("{:?} {:?}", fragment, fragment.rfind('\n'));
   match fragment.rfind('\n') {
     Some(p) => fragment.chars().count() - fragment[..p].chars().count(),
     None => fragment.chars().count() + 1

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -450,7 +450,7 @@ mod tests {
         }
     );
     for token in block_comments {
-      assert_eq!(identify_token_type(token).kind, TokenType::BlockComment);
+      assert_eq!(TokenWithType::from(token).kind, TokenType::BlockComment);
     }
   }
 
@@ -464,7 +464,7 @@ mod tests {
       }
     );
     for token in line_comments {
-      assert_eq!(identify_token_type(token).kind, TokenType::LineComment);
+      assert_eq!(TokenWithType::from(token).kind, TokenType::LineComment);
     }
   }
 
@@ -528,7 +528,7 @@ mod tests {
       }
     );
     for token in not_developer_comments {
-      assert_eq!(identify_token_type(token).kind, TokenType::Other);
+      assert_eq!(TokenWithType::from(token).kind, TokenType::Other);
     }
   }
 

--- a/src/documentation/developer.rs
+++ b/src/documentation/developer.rs
@@ -537,7 +537,7 @@ mod tests {
     assert_eq!(span.start.line, 1);
     assert_eq!(span.start.column, 2);
     assert_eq!(span.end.line, 1);
-    assert_eq!(span.end.column, source.chars().count() - 2);
+    assert_eq!(span.end.column, source.chars().count() - 2 - 1);
   }
 
   #[test]
@@ -562,7 +562,7 @@ mod tests {
     assert_eq!(span.start.line, 1);
     assert_eq!(span.start.column, indent_size + 2);
     assert_eq!(span.end.line, 1);
-    assert_eq!(span.end.column, source.chars().count() - 2);
+    assert_eq!(span.end.column, source.chars().count() - 2 - 1);
   }
 
   #[test]
@@ -588,7 +588,7 @@ mod tests {
       assert_eq!(span.start.line, 1);
       assert_eq!(span.start.column, 2);
       assert_eq!(span.end.line, 1);
-      assert_eq!(span.end.column, "/* block".chars().count());
+      assert_eq!(span.end.column, "/* block".chars().count() - 1);
     }
     {
       let literal = literals.get(1).unwrap();
@@ -600,7 +600,7 @@ mod tests {
       assert_eq!(span.start.line, 2);
       assert_eq!(span.start.column, 0);
       assert_eq!(span.end.line, 2);
-      assert_eq!(span.end.column, " 种 ".chars().count());
+      assert_eq!(span.end.column, " 种 ".chars().count() - 1);
     }
     {
       let literal = literals.get(2).unwrap();
@@ -612,7 +612,7 @@ mod tests {
       assert_eq!(span.start.line, 3);
       assert_eq!(span.start.column, 0);
       assert_eq!(span.end.line, 3);
-      assert_eq!(span.end.column, "comment ".chars().count());
+      assert_eq!(span.end.column, "comment ".chars().count() - 1);
     }
   }
 
@@ -673,7 +673,7 @@ mod tests {
       assert_eq!(span.start.line, 1);
       assert_eq!(span.start.column, 2);
       assert_eq!(span.end.line, 1);
-      assert_eq!(span.end.column, 2 + " First line comment".chars().count());
+      assert_eq!(span.end.column, 2 + " First line comment".chars().count() - 1);
     }
     {
       let literal = literals.get(1).unwrap();
@@ -687,7 +687,7 @@ mod tests {
       assert_eq!(span.start.line, 2);
       assert_eq!(span.start.column, 25);
       assert_eq!(span.end.line, 2);
-      assert_eq!(span.end.column, 25 + " A constant ".chars().count());
+      assert_eq!(span.end.column, 25 + " A constant ".chars().count() - 1);
     }
   }
   #[test]

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -61,7 +61,7 @@ impl CommentVariant {
             ),
         }
     }
-    /// Return legnth of comment prefix for each variant.
+    /// Return length (in bytes) of comment prefix for each variant.
     ///
     /// By definition matches the length of `prefix_string`.
     pub fn prefix_len(&self) -> usize {

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -301,7 +301,7 @@ impl TrimmedLiteral {
                 },
                 end: LineColumn {
                     line,
-                    column: column + content.chars().count() - post_text.chars().count()
+                    column: column + content.chars().count() - post_text.chars().count() - 1
                 }
             },
             rendered: content.to_string(),

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -5,8 +5,6 @@ use anyhow::{bail, Result};
 use fancy_regex::Regex;
 use std::convert::TryFrom;
 use std::fmt;
-use std::error::Error;
-use crate::documentation::developer::{TokenWithLineColumn, TokenWithType};
 use proc_macro2::LineColumn;
 
 /// Track what kind of comment the literal is

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -21,6 +21,10 @@ pub enum CommentVariant {
     MacroDocEq(String, usize),
     /// Commonmark File
     CommonMark,
+    /// Developer line comment
+    DoubleSlash,
+    /// Developer block comment
+    SlashStar,
     /// Unknown Variant
     Unknown,
 }
@@ -49,6 +53,8 @@ impl CommentVariant {
                 format!(r#"{}{}"#, d, raw)
             }
             CommentVariant::CommonMark => "".to_string(),
+            CommentVariant::DoubleSlash => "//".to_string(),
+            CommentVariant::SlashStar => "/*".to_string(),
             unhandled => unreachable!(
                 "String representation for comment variant {:?} exists. qed",
                 unhandled
@@ -62,7 +68,7 @@ impl CommentVariant {
         match self {
             CommentVariant::TripleSlash | CommentVariant::DoubleSlashEM => 3,
             CommentVariant::MacroDocEq(d, p) => d.len() + *p + 1,
-            _ => 0,
+            _ => self.prefix_string().len(),
         }
     }
 

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -3,9 +3,9 @@ use crate::{Range, Span};
 use anyhow::{bail, Result};
 
 use fancy_regex::Regex;
+use proc_macro2::LineColumn;
 use std::convert::TryFrom;
 use std::fmt;
-use proc_macro2::LineColumn;
 
 /// Track what kind of comment the literal is
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -285,10 +285,16 @@ impl TrimmedLiteral {
     /// Creates a new (single line) literal from the variant, the content, the size of the
     /// pre & post and the line/column on which it starts. Fails if provided with multiline content
     /// (i.e if the content contains a linebreak).
-    pub fn from(variant: CommentVariant, content: &str, pre: usize, post: usize, line: usize,
-            column: usize) -> Result<TrimmedLiteral, String> {
+    pub fn from(
+        variant: CommentVariant,
+        content: &str,
+        pre: usize,
+        post: usize,
+        line: usize,
+        column: usize,
+    ) -> Result<TrimmedLiteral, String> {
         if content.contains("\n") {
-            return Err("Cannot create a multiline trimmed literal".to_string())
+            return Err("Cannot create a multiline trimmed literal".to_string());
         }
         let pre_text = &content[..pre];
         let post_text = &content[content.len() - post..];
@@ -297,18 +303,20 @@ impl TrimmedLiteral {
             span: Span {
                 start: LineColumn {
                     line,
-                    column: column + pre_text.chars().count()
+                    column: column + pre_text.chars().count(),
                 },
                 end: LineColumn {
                     line,
-                    column: column + content.chars().count() - post_text.chars().count() - 1
-                }
+                    column: column + content.chars().count() - post_text.chars().count() - 1,
+                },
             },
             rendered: content.to_string(),
             pre,
             post,
-            len_in_chars: content.chars().count() - pre_text.chars().count() - post_text.chars().count(),
-            len_in_bytes: content.len() - pre - post
+            len_in_chars: content.chars().count()
+                - pre_text.chars().count()
+                - post_text.chars().count(),
+            len_in_bytes: content.len() - pre - post,
         })
     }
 }

--- a/src/documentation/mod.rs
+++ b/src/documentation/mod.rs
@@ -29,6 +29,7 @@ pub type Range = core::ops::Range<usize>;
 
 mod chunk;
 mod cluster;
+mod developer;
 mod literal;
 pub(crate) mod literalset;
 mod markdown;


### PR DESCRIPTION
This PR adds support for spellchecking developer comments in addition to documentation comments.

 * 🦚 Feature
snasphysicist
Closes #115

## Changes proposed by this PR:

Adds a new module which is responsible for extracting developer comments from the source, converting them into a format (`LiteralSet`) required by the spellchecker and adds them to the data structure which stores the content to be spellchecked.

This also adds a new dependency - `ra_ap_syntax`.

## Notes to reviewer:

The bulk of the code is in its own, new module (`developer.rs`). We can't use anything from `proc_macro2` since it throws away all information about developer comments so we need to start again from the source file/text, and the new code with tests is quite long (a few hundred lines).

The source is split into tokens, which are then passed through a series of transformations adding more information (location in source, then line and column at which they start, then "type" calculated from a regex). Only block and non-documentation line comments are retained and these are separately converted into `TrimmedLiteral`s/`LiteralSet`s.

The main entry point `extract_developer_comments` is called from `cluster.rs` and the created `LiteralSet`s are added to the cluster's vector of such sets. Since two parsers are currently in use (`proc_macro2` & `ra_ap_syntax`) first one is applied then the other. This means that the comments are initially added to the vector of sets not in the order in which they occur in the file. hence a new method is added to sort this vector by the first line on which each `LiteralSet` occurs.

## Specific TODOs

 * [X] Re-enable strict code/lint checks
 * [X] Lazy static for regexes
 * [X] ~~Fix one unexpectedly failing test for line comments - not sure about the meaning of 'adjacent' in `LiteralSet`~~ (turns out I was being an idiot!)
 * [X] Add parsed `LiteralSet`s to `CheckableChunk` 
 * [X] Document all functions, structs
 * [X] ~~Possibly replace regex with fancy_regex~~? (regex dependency was introduced by another change)
 * [X] Does all the new code live in the right place?
 * [X] Check/squash/tidy old commits

## 📜 Checklist

 * [X] Works on the `./demo` sub directory
 * [X] Test coverage is excellent and passes (IMO :) )
 * [X] Documentation is thorough (IMO :) )
