### PR TITLE
adjust args parsing issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,7 @@ dependencies = [
  "languagetool",
  "lazy_static",
  "log",
+ "maplit",
  "proc-macro2",
  "pulldown-cmark",
  "ra_ap_syntax",
@@ -1046,6 +1047,12 @@ checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ languagetool-rs = { version = "0.1", package = "languagetool", optional = true }
 # for stripping ansi color codes
 console = "0.13"
 assert_matches = "1"
+maplit = "1"
 
 [features]
 default = ["hunspell"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,6 +143,8 @@ impl Args {
             Action::Config
         } else if self.flag_help {
             Action::Help
+        } else if self.flag_version {
+            Action::Version
         } else if self.cmd_check {
             Action::Check
         } else {
@@ -439,30 +441,43 @@ mod tests {
         s.split(' ').map(|s| s.to_owned()).into_iter()
     }
 
+    lazy_static::lazy_static!(
+        static ref SAMPLES: std::collections::HashMap<&'static str, Action> = maplit::hashmap!{
+            "cargo spellcheck" => Action::Check,
+            "cargo spellcheck --version" => Action::Version,
+            "cargo spellcheck reflow" => Action::Reflow,
+            "cargo spellcheck reflow" => Action::Reflow,
+            "cargo spellcheck -vvvv" => Action::Check,
+            "cargo spellcheck --fix" => Action::Fix,
+            "cargo spellcheck fix" => Action::Fix,
+            "cargo-spellcheck" => Action::Check,
+            "cargo-spellcheck -vvvv" => Action::Check,
+            "cargo-spellcheck --fix" => Action::Version,
+            "cargo-spellcheck fix" => Action::Fix,
+            "cargo-spellcheck fix -r file.rs" => Action::Fix,
+            "cargo-spellcheck -q fix Cargo.toml" => Action::Fix,
+            "cargo spellcheck -v fix Cargo.toml" => Action::Fix,
+            "cargo spellcheck -m 11 check" => Action::Check,
+            "cargo-spellcheck reflow" => Action::Reflow,
+        };
+    );
+
     #[test]
     fn docopt() {
-        let commands = vec![
-            "cargo spellcheck",
-            "cargo spellcheck -vvvv",
-            "cargo spellcheck --fix",
-            "cargo spellcheck fix",
-            "cargo-spellcheck",
-            "cargo-spellcheck -vvvv",
-            "cargo-spellcheck --fix",
-            "cargo-spellcheck fix",
-            "cargo-spellcheck fix -r file.rs",
-            "cargo-spellcheck -q fix Cargo.toml",
-            "cargo spellcheck -v fix Cargo.toml",
-            "cargo spellcheck -m 11 check",
-            "cargo-spellcheck reflow",
-        ];
-        for command in commands {
+        for command in SAMPLES.keys() {
             assert!(parse_args(commandline_to_iter(command))
                 .map_err(|e| {
                     println!("Processing > {:?}", command);
                     e
                 })
                 .is_ok());
+        }
+    }
+
+    #[test]
+    fn action_extraction() {
+        for (command, action) in SAMPLES.iter() {
+            assert_eq!(parse_args(commandline_to_iter(command)).expect("Parsing is assured by another unit test. qed").action(), *action);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -477,7 +477,16 @@ mod tests {
     #[test]
     fn action_extraction() {
         for (command, action) in SAMPLES.iter() {
-            assert_eq!(parse_args(commandline_to_iter(command)).expect("Parsing is assured by another unit test. qed").action(), *action);
+            assert_eq!(
+                parse_args(commandline_to_iter(command))
+                    .map_err(|e| {
+                        println!("Processing > {:?}", command);
+                        e
+                    })
+                    .expect("Parsing is assured by another unit test. qed")
+                    .action(),
+                *action
+            );
         }
     }
 }

--- a/src/reflow/mod.rs
+++ b/src/reflow/mod.rs
@@ -9,9 +9,7 @@ use crate::checker::Checker;
 use crate::documentation::{CheckableChunk, Documentation};
 #[cfg(debug_assertions)]
 use crate::util::load_span_from;
-use crate::util::{
-    byte_range_to_char_range, byte_range_to_char_range_many, sub_char_range,
-};
+use crate::util::{byte_range_to_char_range, byte_range_to_char_range_many, sub_char_range};
 
 use crate::{CommentVariant, ContentOrigin, Detector, Range, Span, Suggestion, SuggestionSet};
 

--- a/src/reflow/mod.rs
+++ b/src/reflow/mod.rs
@@ -7,9 +7,12 @@ use anyhow::{anyhow, Result};
 
 use crate::checker::Checker;
 use crate::documentation::{CheckableChunk, Documentation};
+#[cfg(debug_assertions)]
+use crate::util::load_span_from;
 use crate::util::{
-    byte_range_to_char_range, byte_range_to_char_range_many, load_span_from, sub_char_range,
+    byte_range_to_char_range, byte_range_to_char_range_many, sub_char_range,
 };
+
 use crate::{CommentVariant, ContentOrigin, Detector, Range, Span, Suggestion, SuggestionSet};
 
 use indexmap::IndexMap;


### PR DESCRIPTION
## What does this PR accomplish?

 * 🩹 Bug Fix

## Changes proposed by this PR:

Revamp the args sanitization code, add a unit test for the derived action.

## Notes to reviewer:

previously `cargo spellcheck --version` was interpreted as to check the _file_ `--version`.

## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
