### PR TITLE
fix/literal: cover /*, /**, and /*!

### DIFF
--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -1,10 +1,10 @@
 //! Fancy module docs are really helpful if they contain usage examples.
 
-
 /// Pick option a also known as door #1.
 pub fn a() {
 
 }
+
 
 #[doc = "Pick option b also known as door #2."]
 pub fn b() {

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,10 +1,8 @@
-/*! Just a lil smthin smthin.
- */
+/*! Just a lil smthin smthin. */
 
 mod lib;
 
-/* dev
- */
+/* dev */
 pub mod nested;
 
 /**

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,8 +1,15 @@
-//! Just a lil somethin somethin
+/*! Just a lil smthin smthin.
+ */
+
 mod lib;
 
+/* dev
+ */
 pub mod nested;
 
+/**
+Not so preferable doc comment, use `///` instead.
+*/
 fn main() {
     lib::a();
     lib::b();

--- a/src/action/bandaid.rs
+++ b/src/action/bandaid.rs
@@ -132,17 +132,17 @@ l
                 },
                 end: LineColumn {
                     line: 1,
-                    column: 22,
+                    column: 20,
                 },
             },
             Span {
                 start: LineColumn {
                     line: 1,
-                    column: 24,
+                    column: 22,
                 },
                 end: LineColumn {
                     line: 1,
-                    column: 31,
+                    column: 27,
                 },
             },
         ];

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -396,12 +396,7 @@ impl TrimmedLiteral {
             },
         };
 
-        trim_span(
-            content,
-            &mut span,
-            pre,
-            post + 1
-        );
+        trim_span(content, &mut span, pre, post + 1);
 
         Ok(TrimmedLiteral {
             variant,
@@ -409,9 +404,7 @@ impl TrimmedLiteral {
             rendered: content.to_string(),
             pre,
             post,
-            len_in_chars: content_chars_len
-                - pre
-                - post,
+            len_in_chars: content_chars_len - pre - post,
             len_in_bytes: content.len() - pre - post,
         })
     }

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -263,7 +263,8 @@ impl TryFrom<(&str, proc_macro2::Literal)> for TrimmedLiteral {
                 span.end.column -= post;
             } else {
                 // look for the last character in the previous line
-                let previous_line_length = rendered.chars()
+                let previous_line_length = rendered
+                    .chars()
                     .rev()
                     // assumes \n, we want to skip the first one from the back
                     .skip(post + 1)
@@ -589,7 +590,6 @@ impl<'a> fmt::Display for TrimmedLiteralDisplay<'a> {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -607,7 +607,14 @@ mod tests {
                 let tl = TrimmedLiteral::try_from((CONTENT, literal)).unwrap();
                 assert!(CONTENT.starts_with(tl.prefix()));
                 assert!(CONTENT.ends_with(tl.suffix()));
-                assert_eq!(CONTENT.chars().skip(tl.pre()).take(tl.len_in_chars()).collect::<String>(), tl.as_str().to_owned())
+                assert_eq!(
+                    CONTENT
+                        .chars()
+                        .skip(tl.pre())
+                        .take(tl.len_in_chars())
+                        .collect::<String>(),
+                    tl.as_str().to_owned()
+                )
             }
         };
     }
@@ -615,10 +622,16 @@ mod tests {
     block_comment_test!(trimmed_oneline_doc, "/** dooc */");
     block_comment_test!(trimmed_oneline_mod, "/*! dooc */");
 
-    block_comment_test!(trimmed_multi_doc, "/**
+    block_comment_test!(
+        trimmed_multi_doc,
+        "/**
 mood
-*/");
-    block_comment_test!(trimmed_multi_mod, "/*!
+*/"
+    );
+    block_comment_test!(
+        trimmed_multi_mod,
+        "/*!
 mood
-*/");
+*/"
+    );
 }

--- a/src/documentation/tests.rs
+++ b/src/documentation/tests.rs
@@ -1109,7 +1109,9 @@ ff"#,
     );
 }
 
-pub(crate) fn annotated_literals_raw<'a>(source: &'a str) -> impl Iterator<Item=proc_macro2::Literal> + 'a {
+pub(crate) fn annotated_literals_raw<'a>(
+    source: &'a str,
+) -> impl Iterator<Item = proc_macro2::Literal> + 'a {
     let stream = syn::parse_str::<proc_macro2::TokenStream>(source).expect("Must be valid rust");
     stream
         .into_iter()

--- a/src/documentation/tests.rs
+++ b/src/documentation/tests.rs
@@ -1109,9 +1109,7 @@ ff"#,
     );
 }
 
-pub(crate) fn annotated_literals(source: &str) -> Vec<TrimmedLiteral> {
-    use std::convert::TryFrom;
-
+pub(crate) fn annotated_literals_raw<'a>(source: &'a str) -> impl Iterator<Item=proc_macro2::Literal> + 'a {
     let stream = syn::parse_str::<proc_macro2::TokenStream>(source).expect("Must be valid rust");
     stream
         .into_iter()
@@ -1130,6 +1128,12 @@ pub(crate) fn annotated_literals(source: &str) -> Vec<TrimmedLiteral> {
                 None
             }
         })
+}
+
+pub(crate) fn annotated_literals(source: &str) -> Vec<TrimmedLiteral> {
+    use std::convert::TryFrom;
+
+    annotated_literals_raw(source)
         .map(|literal| {
             TrimmedLiteral::try_from((source, literal))
                 .expect("Literals must be convertable to trimmed literals")

--- a/src/reflow/mod.rs
+++ b/src/reflow/mod.rs
@@ -43,7 +43,15 @@ impl Checker for Reflow {
             .try_fold::<SuggestionSet, Result<SuggestionSet>, _, _>(
                 || SuggestionSet::new(),
                 |mut acc, (origin, chunks)| {
-                    for chunk in chunks {
+                    'c: for chunk in chunks {
+                        match chunk.variant() {
+                            CommentVariant::SlashAsterisk
+                            | CommentVariant::SlashAsteriskAsterisk
+                            | CommentVariant::SlashAsteriskEM => {
+                                continue 'c;
+                            }
+                            _ => {}
+                        }
                         let suggestions = reflow(origin, chunk, config)?;
                         acc.extend(origin.clone(), suggestions);
                     }


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

 * 🩹 Bug Fix
 * 🦚 Feature

Correctly extracts block doc comments, which previously printed a warning.

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes #147 .

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

Adds `CommentVariant` variants and parse them correctly.

There is some work left todo to handle ` * ` line prefixes, see https://github.com/drahnr/cargo-spellcheck/issues/157
hence `reflow` is disabled for those types of comments for now.

## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
