### PR TITLE
Remove dependency on enumflags2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,6 @@ dependencies = [
  "crossterm",
  "directories",
  "docopt",
- "enumflags2",
  "env_logger 0.8.3",
  "fancy-regex",
  "fs-err",
@@ -704,26 +703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8946e241a7774d5327d92749c50806f275f57d031d2229ecbfd65469a8ad338e"
 dependencies = [
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "enumflags2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8d82922337cd23a15f88b70d8e4ef5f11da38dd7cdb55e84dd5de99695da0"
-dependencies = [
- "enumflags2_derive",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ crossterm = "0.19"
 # for the config file
 directories = "3"
 docopt = "1"
-enumflags2 = "0.6"
 env_logger = "0.8"
 fancy-regex = "0.5"
 fs-err = "2"

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -16,26 +16,24 @@ use crate::documentation::{CheckableChunk, ContentOrigin};
 use std::cmp;
 use std::convert::TryFrom;
 
-use enumflags2::BitFlags;
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
 use crate::{Range, Span};
 
 /// Bitflag of available checkers by compilation / configuration.
-#[derive(Debug, Clone, Copy, BitFlags, Eq, PartialEq, Hash)]
-#[repr(u16)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Detector {
     /// Hunspell lib based detector.
-    Hunspell = 0b0_0001,
+    Hunspell,
     /// Language tool server based detection.
-    LanguageTool = 0b0_0010,
+    LanguageTool,
     /// Language server rules based on nlp detector.
-    NlpRules = 0b0_0100,
+    NlpRules,
     /// Reflow according to a given max column.
-    Reflow = 0b0_1000,
+    Reflow,
     /// Detection of nothing, a test helper.
     #[cfg(test)]
-    Dummy = 0b1_0000,
+    Dummy,
 }
 
 impl Detector {


### PR DESCRIPTION
## What does this PR accomplish?

Remove an unused dependency - the only use of `enumflags2` was on `suggestion::Detector`,
but a bitfield of that type is never constructed.

 * 🦣 Legacy

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->


## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough