### PR TITLE
feat/errors: migrate to eyre

### DIFF
--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -49,7 +49,9 @@ impl ScopedRaw {
     pub fn restore_terminal() -> Result<()> {
         stdout().queue(crossterm::cursor::Show)?;
         crossterm::terminal::disable_raw_mode()?;
-        stdout().flush().map_err(|e| anyhow::anyhow!(e))
+        stdout()
+            .flush()
+            .wrap_err_with(|| eyre!("Failed to restore terminal"))
     }
 }
 
@@ -424,7 +426,7 @@ impl UserPicked {
             }
 
             let event = match crossterm::event::read()
-                .map_err(|e| anyhow::anyhow!("Something unexpected happened on the CLI: {}", e))?
+                .wrap_err_with(|| eyre!("Something unexpected happened on the CLI"))?
             {
                 Event::Key(event) => event,
                 Event::Resize(..) => {

--- a/src/checker/dummy.rs
+++ b/src/checker/dummy.rs
@@ -5,9 +5,9 @@
 // use super::tokenize;
 use super::{apply_tokenizer, Checker};
 use crate::documentation::Documentation;
+use crate::errors::*;
 use crate::suggestion::{Detector, Suggestion, SuggestionSet};
 use crate::util::sub_chars;
-use anyhow::Result;
 use log::trace;
 
 /// A test checker that tokenizes and marks everything as wrong

--- a/src/checker/hunspell.rs
+++ b/src/checker/hunspell.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use hunspell_rs::Hunspell;
 
-use anyhow::{anyhow, bail, Result};
+use crate::errors::*;
 
 use super::quirks::{
     replacements_contain_dashed, replacements_contain_dashless, transform, Transformed,
@@ -165,7 +165,7 @@ impl HunspellChecker {
                 Some((dic, aff))
             })
             .ok_or_else(|| {
-                anyhow!("Failed to find any {lang}.dic / {lang}.aff in any search dir or no search provided",
+                eyre!("Failed to find any {lang}.dic / {lang}.aff in any search dir or no search provided",
                     lang = lang)
             })
             .or_else(|e| {
@@ -415,12 +415,11 @@ fn is_valid_hunspell_dic(reader: impl BufRead) -> Result<()> {
     let mut iter = reader.lines().enumerate();
     if let Some((_lineno, first)) = iter.next() {
         let first = first?;
-        let _ = first.parse::<u64>().map_err(|e| {
-            anyhow!(
+        let _ = first.parse::<u64>().wrap_err_with(|| {
+            eyre!(
                 "First line of extra dictionary must a number, but is: >{}<",
                 first
             )
-            .context(e)
         })?;
     }
     // Just check the first 10 lines, don't waste much time here

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -6,7 +6,7 @@
 
 use crate::{Config, Detector, Documentation, Suggestion, SuggestionSet};
 
-use anyhow::Result;
+use crate::errors::*;
 
 use log::debug;
 

--- a/src/checker/nlprules.rs
+++ b/src/checker/nlprules.rs
@@ -6,7 +6,7 @@
 use super::{Checker, Detector, Documentation, Suggestion, SuggestionSet};
 use crate::{CheckableChunk, ContentOrigin};
 
-use anyhow::Result;
+use crate::errors::*;
 use log::{debug, trace, warn};
 use rayon::prelude::*;
 

--- a/src/checker/tokenize.rs
+++ b/src/checker/tokenize.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::errors::*;
 use fs_err as fs;
 use lazy_static::lazy_static;
 use log::info;

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -1,6 +1,6 @@
 use std::{marker::PhantomData, path::PathBuf};
 
-use anyhow::{bail, Result};
+use crate::errors::*;
 use docopt::Docopt;
 
 use crate::traverse;

--- a/src/config/hunspell.rs
+++ b/src/config/hunspell.rs
@@ -3,7 +3,7 @@
 use super::{Lang5, SearchDirs, WrappedRegex};
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Result};
+use crate::errors::*;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -4,7 +4,6 @@
 
 use super::*;
 
-use anyhow::{bail, Error, Result};
 use indexmap::IndexMap;
 use std::convert::TryFrom;
 use std::fmt;

--- a/src/documentation/cluster.rs
+++ b/src/documentation/cluster.rs
@@ -3,8 +3,8 @@
 use super::{trace, LiteralSet, Spacing, TokenTree, TrimmedLiteral, TryInto};
 use crate::documentation::developer::extract_developer_comments;
 use crate::documentation::Range;
+use crate::errors::*;
 use crate::Span;
-use anyhow::{anyhow, Result};
 use std::convert::TryFrom;
 
 /// Cluster literals for one file
@@ -116,7 +116,7 @@ impl Clusters {
             set: Vec::with_capacity(64),
         };
         let stream = syn::parse_str::<proc_macro2::TokenStream>(source)
-            .map_err(|e| anyhow!("Failed to parse content to stream").context(e))?;
+            .wrap_err_with(|| eyre!("Failed to parse content to stream"))?;
         chunk.parse_token_tree(source, stream)?;
         if dev_comments {
             chunk.parse_developer_comments(source);

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -1,6 +1,6 @@
+use crate::errors::*;
 use crate::util::{self, sub_chars};
 use crate::{Range, Span};
-use anyhow::{bail, Result};
 
 use fancy_regex::Regex;
 use lazy_static::lazy_static;
@@ -190,7 +190,7 @@ fn trim_span(content: &str, span: &mut Span, pre: usize, post: usize) {
 }
 
 impl TryFrom<(&str, proc_macro2::Literal)> for TrimmedLiteral {
-    type Error = anyhow::Error;
+    type Error = Error;
     fn try_from((content, literal): (&str, proc_macro2::Literal)) -> Result<Self> {
         // let rendered = literal.to_string();
         // produces pretty unusable garabage, since it modifies the content of `///`

--- a/src/documentation/mod.rs
+++ b/src/documentation/mod.rs
@@ -14,8 +14,8 @@
 
 use super::*;
 
+use crate::errors::*;
 use crate::util::load_span_from;
-use anyhow::{anyhow, Result};
 use indexmap::IndexMap;
 use log::trace;
 pub use proc_macro2::LineColumn;
@@ -149,7 +149,7 @@ impl Documentation {
                 line: linenumber,
                 column: linecontent.chars().count().saturating_sub(1),
             })
-            .ok_or_else(|| anyhow!("Common mark / markdown file does not contain a single line"))?;
+            .ok_or_else(|| eyre!("Common mark / markdown file does not contain a single line"))?;
 
         let span = Span { start, end };
         let source_mapping = indexmap::indexmap! {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,2 @@
+//! Global error usage without cluttering each file.
+pub use color_eyre::eyre::{bail, eyre, Error, Result, WrapErr};

--- a/src/reflow/mod.rs
+++ b/src/reflow/mod.rs
@@ -3,7 +3,7 @@
 //! Note that for commonmark this might not be possible with links.
 //! The reflow is done based on the comments no matter the content.
 
-use anyhow::{anyhow, Result};
+use crate::errors::*;
 
 use crate::checker::Checker;
 use crate::documentation::{CheckableChunk, Documentation};
@@ -187,7 +187,7 @@ fn reflow_inner<'s>(
     let last_indent = indentations
         .last()
         .copied()
-        .ok_or_else(|| anyhow!("No line indentation present."))?;
+        .ok_or_else(|| eyre!("No line indentation present."))?;
 
     // First line has to be without indent and variant prefix.
     // If there is nothing to reflow, just pretend there was no reflow.

--- a/src/span.rs
+++ b/src/span.rs
@@ -10,7 +10,7 @@ pub use proc_macro2::LineColumn;
 
 use std::hash::{Hash, Hasher};
 
-use anyhow::{bail, Error, Result};
+use crate::errors::*;
 
 use std::convert::TryFrom;
 

--- a/src/traverse/iter.rs
+++ b/src/traverse/iter.rs
@@ -1,13 +1,11 @@
 use super::*;
 use crate::Documentation;
 
-use std::fs;
+use fs_err as fs;
 
 use log::{trace, warn};
 
 use std::path::{Path, PathBuf};
-
-use anyhow::Result;
 
 /// An iterator traversing module hierarchies yielding paths
 #[derive(Debug, Clone)]
@@ -33,12 +31,8 @@ impl TraverseModulesIter {
         P: AsRef<Path>,
     {
         let path = path.as_ref();
-        let path = path
-            .canonicalize()
-            .map_err(|e| anyhow!("Failed to canonicalize path {}", path.display()).context(e))?;
-        let meta = path.metadata().map_err(|e| {
-            anyhow!("Failed to obtain meta data for path {}", path.display()).context(e)
-        })?;
+        let path = fs::canonicalize(path)?;
+        let meta = fs::metadata(&path)?;
         if meta.is_file() {
             self.queue.push_back((path, level));
         } else if meta.is_dir() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
+use crate::errors::*;
 use crate::{LineColumn, Range, Span};
-use anyhow::{anyhow, bail, Result};
+use fs_err as fs;
 use std::io::Read;
 use std::path::Path;
 
@@ -89,14 +90,9 @@ where
 #[allow(unused)]
 pub(crate) fn load_span_from_file(path: impl AsRef<Path>, span: Span) -> Result<String> {
     let path = path.as_ref();
-    let path = path
-        .canonicalize()
-        .map_err(|e| anyhow!("Failed to canonicalize {}", path.display()).context(e))?;
+    let path = fs::canonicalize(&path)?;
 
-    let ro = std::fs::OpenOptions::new()
-        .read(true)
-        .open(&path)
-        .map_err(|e| anyhow!("Failed to open {}", path.display()).context(e))?;
+    let ro = fs::OpenOptions::new().read(true).open(&path)?;
 
     let mut reader = std::io::BufReader::new(ro);
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

Jump to `color_eyre`.

<!---
Delete all that do not apply:
-->

 * 🦚 Feature

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes #127 .

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->
Rather big changeset, unspectacular changes though. Also uses `fs_err` more consistently and remove thus useless `.context` calls which were previously needed.


## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
