### PR TITLE
fix/traverse: if recurse, collect flat files, otherwise traverse dirs

### DIFF
--- a/demo/member/stray.rs
+++ b/demo/member/stray.rs
@@ -1,0 +1,2 @@
+/// Nobady references this.
+struct Lost;


### PR DESCRIPTION
Return to the initial traversal via `mod foo` decls and `Cargo.toml`
manifest parsing as soon as one is encountered.

## What does this PR accomplish?

Make traverse more predictable.

 * 🩹 Bug Fix
 * 🦚 Feature

## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
