### PR TITLE
workaround: assure the tokenizer recognizes i.e. isn't as one token

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,7 @@ fn main() -> std::result::Result<(), Box<(dyn std::error::Error + 'static)>> {
                             .expect("Extension conversion from OSString to regular string works. qed") })
                             .unwrap_or_else(|| String::with_capacity(4));
 
-                    ext.push_str(".");
+                    ext.push('.');
                     ext.push_str(COMPRESSION_EXTENSION);
                     path.set_extension(ext);
                     Ok(path)

--- a/src/checker/tokenize.rs
+++ b/src/checker/tokenize.rs
@@ -76,18 +76,61 @@ pub(crate) fn apply_tokenizer<'t, 'z>(
 where
     't: 'z,
 {
+
     tokenizer
         .pipe(text)
         .into_iter()
         .map(|sentence| {
-            sentence.into_iter().filter_map(|token| {
-                let char_range = token.span().char();
-                if char_range.is_empty() {
-                    None
-                } else {
-                    Some(char_range.clone())
+            let mut backlog = Vec::with_capacity(4);
+            let mut acc = Vec::with_capacity(32);
+            let mut iter = sentence
+                .into_iter()
+                .filter(|token| !token.span().char().is_empty())
+                .peekable();
+
+            // special cases all abbreviated variants, i.e. `isn't` such
+            // that the tokenizer treats them as a single word.
+            while let Some(token) = iter.next() {
+                let char_range = token.span().char().clone();
+                backlog.push(char_range);
+                if let Some(upcoming) = iter.peek() {
+                    let s = upcoming.word().text().as_str();
+                    if s == "'" && !upcoming.has_space_before() {
+                        backlog.push(upcoming.span().char().clone());
+                        let _ = iter.next();
+                        if let Some(upcoming2) = iter.peek() {
+                            let s = upcoming2.word().text().as_str();
+                            if s.len() == 1 && !upcoming2.has_space_before() {
+                                acc.push(backlog.first().unwrap().start .. upcoming2.span().char().end);
+                                backlog.clear();
+                                let _ = iter.next();
+                                continue;
+                            }
+                        }
+                    }
                 }
-            })
+                acc.extend(backlog.drain(..));
+            }
+            acc.into_iter()
         })
         .flatten()
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenizer_for_abbrev() {
+        let tok = tokenizer::<PathBuf>(None).unwrap();
+        let ranges = apply_tokenizer(&tok, "It isn't that different.");
+
+        ranges
+            .zip([0_usize..2, 3..8, 9..13, 14..23, 23..24].iter().cloned())
+            .for_each(|(is, expect)| {
+                assert_eq!(is, expect);
+            });
+    }
 }

--- a/src/checker/tokenize.rs
+++ b/src/checker/tokenize.rs
@@ -76,7 +76,6 @@ pub(crate) fn apply_tokenizer<'t, 'z>(
 where
     't: 'z,
 {
-
     tokenizer
         .pipe(text)
         .into_iter()
@@ -101,7 +100,9 @@ where
                         if let Some(upcoming2) = iter.peek() {
                             let s = upcoming2.word().text().as_str();
                             if s.len() == 1 && !upcoming2.has_space_before() {
-                                acc.push(backlog.first().unwrap().start .. upcoming2.span().char().end);
+                                acc.push(
+                                    backlog.first().unwrap().start..upcoming2.span().char().end,
+                                );
                                 backlog.clear();
                                 let _ = iter.next();
                                 continue;
@@ -115,8 +116,6 @@ where
         })
         .flatten()
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #![deny(missing_docs)]
 #![deny(unused_crate_dependencies)]
 #![warn(clippy::pedantic)]
+#![allow(clippy::non_ascii_literal)]
 
 //! cargo-spellcheck
 //!


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

Adds some special casing to avoid splitting `isn't` and `he'd` into multiple tokens, to avoid spellchecking with hunspell rightly flaging `isn` and `t`.

 * 🩹 Bug Fix

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes #178 

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->


## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
