### PR TITLE
tokenizer quirks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,6 @@ build-override = { opt-level = 2 }
 
 [profile.release]
 debug = true
+
+[package.metadata.spellcheck]
+config = ".config/spellcheck.toml"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,37 @@ derived from `languagetool`) are currently the two supported checkers.
 
 ## Configuration
 
+### Source
+
+There are various ways to specify the configuration. The prioritization is as
+follows:
+
+_Explicit_ specification:
+
+1. Command line flags `--cfg=...`.
+1. `Cargo.toml` metadata:
+
+    ```toml
+    [package.metadata.spellcheck]
+    config = "somewhere/cfg.toml"
+    ```
+
+which will fail if specified and not existent on the filesystem.
+
+If neither of those ways of specification is present, continue with the
+_implicit_.
+
+1. Check the first arguments location if present, else the current working directory for `.config/spellcheck.toml`
+1. Fallback to per user configuration files:
+    * Linux:   `/home/alice/.config/cargo_spellcheck/config.toml`
+    * Windows: `C:\Users\Alice\AppData\Roaming\cargo_spellcheck\config.toml`
+    * macOS:   `/Users/Alice/Library/Preferences/cargo_spellcheck/config.toml`
+1. Use the default, builtin configuration (see `config` sub-command).
+
+Since this is rather complex, add `-vv` to your invocation to see the `info`
+level logs printed, which will contain the config path.
+### Format
+
 ```toml
 # Project settings where a Cargo.toml exists and is passed
 # ${CARGO_MANIFEST_DIR}/.config/spellcheck.toml
@@ -104,13 +135,6 @@ dev_comments = false
 
 # Skip the README.md file as defined in the cargo manifest
 skip_readme = false
-
-# Fallback to per use configuration files:
-# Linux:   /home/alice/.config/cargo_spellcheck/config.toml
-# Windows: C:\Users\Alice\AppData\Roaming\cargo_spellcheck\config.toml
-# macOS:   /Users/Alice/Library/Preferences/cargo_spellcheck/config.toml
-
-
 
 [Hunspell]
 # lang and name of `.dic` file

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -107,6 +107,7 @@ pub mod dummy;
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::load_span_from;
     use crate::span::Span;
     use crate::ContentOrigin;
     use crate::LineColumn;
@@ -164,7 +165,14 @@ pub mod tests {
                 vec![format!("replacement_{}", index)],
                 "found vs expected replacement"
             );
-            assert_eq!(suggestion.span, *expected_span, "found vs expected span");
+            let extracts = load_span_from(&mut content.as_bytes(), suggestion.span).unwrap();
+            let expected_extracts =
+                load_span_from(&mut content.as_bytes(), *expected_span).unwrap();
+            assert_eq!(
+                (suggestion.span, extracts),
+                (*expected_span, expected_extracts),
+                "found vs expected span"
+            );
         }
     }
 

--- a/src/checker/tokenize.rs
+++ b/src/checker/tokenize.rs
@@ -104,11 +104,14 @@ where
             while let Some(token) = iter.next() {
                 let char_range = token.span().char().clone();
 
-                let space = iter.peek().map(|upcoming| upcoming.has_space_before()).unwrap_or(false);
+                let space = iter
+                    .peek()
+                    .map(|upcoming| upcoming.has_space_before())
+                    .unwrap_or(false);
                 let s = token.word().as_str();
                 let belongs_to_genitive_s = match s {
-                        "(" | ")" | r#"""# => false,
-                        _ => true,
+                    "(" | ")" | r#"""# => false,
+                    _ => true,
                 };
                 stage = if belongs_to_genitive_s {
                     match stage {
@@ -142,6 +145,7 @@ where
                     Stage::Empty
                 };
             }
+            acc.extend(backlog.drain(..));
             acc.into_iter()
         })
         .flatten()
@@ -204,11 +208,7 @@ mod tests {
         let ranges = apply_tokenizer(&tok, "the ('lock funds') transaction");
 
         ranges
-            .zip(
-                [0_usize..3, 4..5, 5..6, 6..10, 11..16]
-                    .iter()
-                    .cloned(),
-            )
+            .zip([0_usize..3, 4..5, 5..6, 6..10, 11..16].iter().cloned())
             .for_each(|(is, expect)| {
                 assert_eq!(is, expect);
             });
@@ -236,11 +236,7 @@ mod tests {
         let ranges = apply_tokenizer(&tok, r#"the (Xyz's) do"#);
 
         ranges
-            .zip(
-                [0_usize..3, 4..5, 5..10, 10..11, 12..14]
-                    .iter()
-                    .cloned(),
-            )
+            .zip([0_usize..3, 4..5, 5..10, 10..11, 12..14].iter().cloned())
             .for_each(|(is, expect)| {
                 assert_eq!(is, expect);
             });
@@ -252,11 +248,31 @@ mod tests {
         let ranges = apply_tokenizer(&tok, r#"The Y's car is yellow."#);
 
         ranges
-            .zip(
-                [0_usize..3, 4..7, 8..11]
-                    .iter()
-                    .cloned(),
-            )
+            .zip([0_usize..3, 4..7, 8..11].iter().cloned())
+            .for_each(|(is, expect)| {
+                assert_eq!(is, expect);
+            });
+    }
+
+    #[test]
+    fn tokenize_foo_dot() {
+        let tok = tokenizer::<PathBuf>(None).unwrap();
+        let ranges = apply_tokenizer(&tok, r#"Foo."#);
+
+        ranges
+            .zip([0_usize..3, 3..4].iter().cloned())
+            .for_each(|(is, expect)| {
+                assert_eq!(is, expect);
+            });
+    }
+
+    #[test]
+    fn tokenize_foo() {
+        let tok = tokenizer::<PathBuf>(None).unwrap();
+        let ranges = apply_tokenizer(&tok, r#"foo"#);
+
+        ranges
+            .zip([0_usize..3].iter().cloned())
             .for_each(|(is, expect)| {
                 assert_eq!(is, expect);
             });

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -442,7 +442,6 @@ impl Args {
             }
             let config_path = manifest_path.join(".config").join("spellcheck.toml");
             debug!("Using configuration file (3) {}", config_path.display());
-            let config_path = config_path.canonicalize()?;
             if let Some(cfg) = Config::load_from(&config_path)? {
                 return Ok((cfg, Some(config_path)));
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -98,26 +98,39 @@ impl Config {
         Ok(toml::from_str(s.as_ref())?)
     }
 
-    pub fn load_from<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let mut file = fs::File::open(path.as_ref().to_str().unwrap())?;
+    pub fn load_from<P: AsRef<Path>>(path: P) -> Result<Option<Self>> {
+        let mut file = match fs::File::open(path.as_ref()) {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(None);
+            }
+            Err(e) => bail!(e),
+            Ok(file) => file,
+        };
         let mut contents = String::with_capacity(1024);
-        file.read_to_string(&mut contents)?;
-        Self::parse(&contents)
-            .wrap_err_with(|| {
-                eyre!(
-                    "Syntax of a given config file({}) is broken",
-                    path.as_ref().display()
-                )
-            })
-            .and_then(|mut cfg| {
-                if let Some(base) = path.as_ref().parent() {
-                    cfg.sanitize_paths(base)?;
-                }
-                Ok(cfg)
-            })
+        if let Err(e) = file.read_to_string(&mut contents) {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                Ok(None)
+            } else {
+                bail!(e)
+            }
+        } else {
+            Self::parse(&contents)
+                .wrap_err_with(|| {
+                    eyre!(
+                        "Syntax of a given config file({}) is broken",
+                        path.as_ref().display()
+                    )
+                })
+                .and_then(|mut cfg| {
+                    if let Some(base) = path.as_ref().parent() {
+                        cfg.sanitize_paths(base)?;
+                    }
+                    Ok(Some(cfg))
+                })
+        }
     }
 
-    pub fn load() -> Result<Self> {
+    pub fn load() -> Result<Option<Self>> {
         if let Some(base) = directories::BaseDirs::new() {
             Self::load_from(
                 base.config_dir()

--- a/src/documentation/tests.rs
+++ b/src/documentation/tests.rs
@@ -76,7 +76,7 @@ macro_rules! end2end {
     ($test:expr, $origin:expr, $n:expr, $checker:ty) => {{
         let _ = env_logger::builder()
             .is_test(true)
-            .filter(None, log::LevelFilter::Trace)
+            .filter_level(log::LevelFilter::Trace)
             .try_init();
 
         let origin: ContentOrigin = $origin;
@@ -87,13 +87,14 @@ macro_rules! end2end {
         let chunk = &chunks[0];
         let _plain = chunk.erase_cmark();
 
-        let cfg = Default::default();
-        let suggestion_set =
-            <$checker>::check(&docs, &cfg).expect("Must not fail to extract suggestions");
-        let (_, suggestions) = suggestion_set
+        let cfg = dbg!(Default::default());
+        dbg!(std::any::type_name::<$checker>());
+        let suggestion_set = <$checker as Checker>::check(&docs, &cfg)
+            .expect("Must not fail to extract suggestions");
+        let (_, suggestions) = dbg!(&suggestion_set)
             .iter()
             .next()
-            .expect("Must contain exactly one item");
+            .expect("Suggestion set must not be empty");
         assert_eq!(suggestions.len(), $n);
     }};
 }


### PR DESCRIPTION
## What does this PR accomplish?

Address a few special cases of tokenization with `)` and friends combined with `'s` variants.
Also add `Cargo.toml` metdata parsing.

```toml
[metadata.spellcheck]
config = "relative/path/to/manifest/config.toml"
```

 * :peacock: Feature
 * 🩹 Bug 

## Changes proposed by this PR:

Adjust the tokenizer to ignore `"` and `(` for pre segements of the token.

## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
