### PR TITLE
fix/arg: check more places for configs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ follows:
 _Explicit_ specification:
 
 1. Command line flags `--cfg=...`.
-1. `Cargo.toml` metadata:
+1. `Cargo.toml` metadata
 
     ```toml
     [package.metadata.spellcheck]
@@ -115,7 +115,8 @@ which will fail if specified and not existent on the filesystem.
 If neither of those ways of specification is present, continue with the
 _implicit_.
 
-1. Check the first arguments location if present, else the current working directory for `.config/spellcheck.toml`
+1. `Cargo.toml` metadata in the currend working dir `CWD`.
+1. Check the first arguments location if present, else the current working directory for `.config/spellcheck.toml`.
 1. Fallback to per user configuration files:
     * Linux:   `/home/alice/.config/cargo_spellcheck/config.toml`
     * Windows: `C:\Users\Alice\AppData\Roaming\cargo_spellcheck\config.toml`


### PR DESCRIPTION
Iff one argument is passed, also attempt to get the cargo manifest metadata from
the a manifest in the cwd iff one is present and there is none in the target dir specified.

Also moves the `.config/spellcheck.toml` lookup relative to the cwd.

<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

 * 🩹 Bug Fix

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes # .

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->


## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
