### PR TITLE
Port to fd-lock 3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,10 +608,11 @@ dependencies = [
 
 [[package]]
 name = "fd-lock"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0010f02effd88c702318c5dde0463206be67495d0b4d906ba7c0a8f166cc7f06"
+checksum = "b8806dd91a06a7a403a8e596f9bfbfb34e469efbc363fc9c9713e79e26472e36"
 dependencies = [
+ "cfg-if 1.0.0",
  "libc",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ url = { version = "2", features = ["serde"] }
 
 # dictionary lookup with affixes
 hunspell-rs = { version = "0.3", optional = true }
-fd-lock = { version = "2", optional = true }
+fd-lock = { version = "3", optional = true }
 
 # full grammar check, but also tokenization and disambiguation
 nlprule = { version = "=0.6.4", optional = true }


### PR DESCRIPTION

<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

 * 🪣 Misc

## Changes proposed by this PR:

fd-lock 3 replaces `FdLock` with `RwLock`, with an API similar to
`std::sync::RwLock`.

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->


## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
