### PR TITLE
replaced regex with memchr in src/reflow/mod.rs and updated some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "lazy_static",
  "log",
  "maplit",
+ "memchr",
  "nlprule",
  "nlprule-build",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,12 +45,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
-
-[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,10 +205,10 @@ dependencies = [
  "color-eyre",
  "console",
  "crossterm",
- "directories",
+ "directories 4.0.1",
  "docopt",
- "env_logger 0.8.4",
- "fancy-regex 0.6.0",
+ "env_logger 0.9.0",
+ "fancy-regex 0.7.1",
  "fd-lock",
  "fs-err",
  "glob",
@@ -237,7 +231,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_plain",
- "signal-hook 0.3.9",
+ "signal-hook",
  "syn",
  "thiserror",
  "toml",
@@ -248,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3596addfb02dcdc06f5252ddda9f3785f9230f5827fb4284645240fa05ad92"
+checksum = "c6d613611c914a7db07f28526941ce1e956d2f977b0c5e2014fbfa42230d420f"
 dependencies = [
  "serde",
  "serde_derive",
@@ -433,25 +427,25 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c36c10130df424b2f3552fcc2ddcd9b28a27b1e54b358b45874f88d1ca6888c"
+checksum = "486d44227f71a1ef39554c0dc47e44b9f4139927c75043312690c3f476d1d788"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "lazy_static",
  "libc",
  "mio",
  "parking_lot",
- "signal-hook 0.1.17",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da8964ace4d3e4a044fd027919b2237000b24315a37c916f61809f1ff2140b9"
+checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
 dependencies = [
  "winapi",
 ]
@@ -482,6 +476,15 @@ name = "directories"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e69600ff1703123957937708eb27f7a564e48885c537782722ed0ba3189ce1d7"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
 dependencies = [
  "dirs-sys",
 ]
@@ -566,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime 2.1.0",
@@ -599,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3371ac125221b609ce0cf587a53fbb624fb56267bbe85cf1929350043bf360"
+checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
 dependencies = [
  "bit-set",
  "regex",
@@ -796,6 +799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,7 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown",
+ "hashbrown 0.9.1",
  "rayon",
  "serde",
 ]
@@ -1024,9 +1033,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libloading"
@@ -1173,7 +1182,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "697cd18b2576102643561a9889203937e0c117c2a88413659a1fbdbf8cc30480"
 dependencies = [
- "directories",
+ "directories 3.0.2",
  "flate2",
  "fs-err",
  "nlprule",
@@ -1416,24 +1425,24 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_la-arena"
-version = "0.0.61"
+version = "0.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23977b341aaa7ee333c46592f12675eab614973141f4310b6b21ca4a741fd4a8"
+checksum = "642b9f33634247cae29d74c8c430de047584015ae9552fad76b6fec44b32e89a"
 
 [[package]]
 name = "ra_ap_parser"
-version = "0.0.61"
+version = "0.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ad440120155232805c13b24547ac44da3f7286f6a6571405f8108203bc3fd"
+checksum = "4152188dad82352c5c3bcfc51cb8d8868ff5c14baa1eee89d6367fd2924e912c"
 dependencies = [
  "drop_bomb",
 ]
 
 [[package]]
 name = "ra_ap_profile"
-version = "0.0.61"
+version = "0.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce81ff253390a56dff3dcc45ff0ef7f3e016fcc61ccd24f56e7d2fa25056c37"
+checksum = "7df74936e0433ef61324efc295eead277e34ab4b9171e6f4d769283e7094d18c"
 dependencies = [
  "cfg-if 1.0.0",
  "countme",
@@ -1446,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_stdx"
-version = "0.0.61"
+version = "0.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9488ca8c028cba5e85276ba83936fd74723d2bf32b6f1224b5cb8b8c0ffec75a"
+checksum = "28ad1f3049780c62dadf140e63676fd396cc65a524d26a0b172873b4b52c37a9"
 dependencies = [
  "always-assert",
  "libc",
@@ -1458,11 +1467,10 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_syntax"
-version = "0.0.61"
+version = "0.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b33c125fc174f5d11e7a0df2b29c6053b42d1f9dfd51f62d42d5bf556ac854"
+checksum = "cc11a27ffcfe72124f85b3fbb3c4dba35320945652fc554c88ff5242dcfbeb43"
 dependencies = [
- "arrayvec",
  "cov-mark",
  "indexmap",
  "itertools 0.10.1",
@@ -1474,15 +1482,14 @@ dependencies = [
  "rowan",
  "rustc-ap-rustc_lexer",
  "rustc-hash",
- "serde",
  "smol_str",
 ]
 
 [[package]]
 name = "ra_ap_text_edit"
-version = "0.0.61"
+version = "0.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe13446e360fc5881e43c8f2004750d4deff88d35f15ce0f16263f15a07b163"
+checksum = "c81e438d99c390f2f546decf58d8669cf376ab48bd6450464a82c95df1a2218b"
 dependencies = [
  "text-size",
 ]
@@ -1726,12 +1733,12 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.13.0-pre.6"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ccc04e145e9a5ab51b9c12a81d77c4a8250d87a407ab02ac650451141ff00d"
+checksum = "4f77412a3d1f26af0c0783c23b3555a301b1a49805cba7bf9a7827a9e9e285f0"
 dependencies = [
  "countme",
- "hashbrown",
+ "hashbrown 0.11.2",
  "memoffset",
  "rustc-hash",
  "text-size",
@@ -1748,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "721.0.0"
+version = "725.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba1f60e2942dc7dc5ea64edeaae01cfba2303871b14936e1af0f54d5420b3d1"
+checksum = "f950742ef8a203aa7661aad3ab880438ddeb7f95d4b837c30d65db1a2c5df68e"
 dependencies = [
  "unicode-xid",
 ]
@@ -1813,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
@@ -1834,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1902,23 +1909,23 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
-dependencies = [
- "libc",
- "mio",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
 dependencies = [
  "libc",
  "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
 ]
 
 [[package]]
@@ -1953,9 +1960,6 @@ name = "smol_str"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ca0f7ce3a29234210f0f4f0b56f8be2e722488b95cb522077943212da3b32eb"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ xz2 = "0.1"
 
 [dependencies]
 color-eyre = "0.5"
-cargo_toml = "0.9"
+cargo_toml = "0.10.1"
 console = "0.14"
-crossterm = "0.19"
+crossterm = "0.21.0"
 # for the config file
-directories = "3"
+directories = "4.0.1"
 docopt = "1"
-env_logger = "0.8"
-fancy-regex = "0.6"
+env_logger = "0.9.0"
+fancy-regex = "0.7.1"
 fs-err = "2"
 indexmap = { version = "1", features=["rayon", "serde"] }
 itertools = "0.10"
@@ -45,9 +45,9 @@ log = "0.4"
 num_cpus = "1.13"
 proc-macro2 = { version = "1", features = ["span-locations"] }
 pulldown-cmark = "0.8.0"
-ra_ap_syntax = "0.0.61"
+ra_ap_syntax = "0.0.75"
 rayon = "1.5"
-regex = "1.4"
+regex = "1.5"
 serde = { version = "1", features = ["derive"] }
 signal-hook = "0.3"
 syn = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ fs-err = "2"
 indexmap = { version = "1", features=["rayon", "serde"] }
 itertools = "0.10"
 lazy_static = "1"
+memchr = "2"
 log = "0.4"
 num_cpus = "1.13"
 proc-macro2 = { version = "1", features = ["span-locations"] }

--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -253,22 +253,22 @@ impl UserPicked {
     fn print_replacements_list(&self, state: &mut State) -> Result<()> {
         let mut stdout = stdout();
 
-        let tick = ContentStyle::new()
-            .foreground(Color::Green)
-            .attribute(Attribute::Bold);
+        let mut tick = ContentStyle::new();
+        tick.foreground_color = Some(Color::Green);
+        tick.attributes = Attribute::Bold.into();
 
-        let highlight = ContentStyle::new()
-            .background(Color::Black)
-            .foreground(Color::Green)
-            .attribute(Attribute::Bold);
+        let mut highlight = ContentStyle::new();
+        highlight.background_color = Some(Color::Black);
+        highlight.foreground_color = Some(Color::Green);
+        highlight.attributes = Attribute::Bold.into();
 
-        let others = ContentStyle::new()
-            .background(Color::Black)
-            .foreground(Color::Blue);
+        let mut others = ContentStyle::new();
+        others.background_color = Some(Color::Black);
+        others.foreground_color = Some(Color::Blue);
 
-        let custom = ContentStyle::new()
-            .background(Color::Black)
-            .foreground(Color::Yellow);
+        let mut custom = ContentStyle::new();
+        custom.background_color = Some(Color::Black);
+        custom.foreground_color = Some(Color::Yellow);
 
         // render all replacements in a vertical list
 
@@ -367,9 +367,9 @@ impl UserPicked {
         {
             let _guard = ScopedRaw::new();
 
-            let boring = ContentStyle::new()
-                .foreground(Color::Blue)
-                .attribute(Attribute::Bold);
+            let mut boring = ContentStyle::new();
+            boring.foreground_color = Some(Color::Blue);
+            boring.attributes = Attribute::Bold.into();
 
             let question = format!(
                 "({nth}/{of_n}) Apply this suggestion [y,n,q,a,d,j,e,?]?",

--- a/src/reflow/mod.rs
+++ b/src/reflow/mod.rs
@@ -78,6 +78,65 @@ struct LineSepStat {
 
 #[inline(always)]
 fn extract_delimiter_inner<'a>(
+    mut iter: impl Iterator<Item=usize>,
+    newline: &'static str,
+) -> Option<LineSepStat> {
+    if let Some(first) = iter.next() {
+        let first = first;
+        let n = iter.count() + 1;
+        Some(LineSepStat {
+            first_appearance: first,
+            count: n,
+            newline,
+        })
+    } else {
+        None
+    }
+}
+
+/// Extract line delimiter of a string.
+pub fn extract_delimiter<'s>(s: &'s str) -> Option<&'static str> {
+    // TODO lots of room for optimizations here
+    let lf = memchr::memchr_iter(b'\n', s.as_bytes());
+    let cr = memchr::memchr_iter(b'\r', s.as_bytes());
+    let crlf = memchr::memmem::find_iter(s.as_bytes(), "\r\n");
+    let lfcr = memchr::memmem::find_iter(s.as_bytes(), "\n\r");
+    // first look for two letter line delimiters
+    let lfcr = extract_delimiter_inner(lfcr, "\n\r");
+    let crlf = extract_delimiter_inner(crlf, "\r\n");
+
+    // remove the 2 line line delimiters from the single line line delimiters, since they overlap
+    let lf = extract_delimiter_inner(lf, "\n").map(|mut stat| {
+        stat.count = stat.count.saturating_sub(std::cmp::max(
+            crlf.as_ref().map(|stat| stat.count).unwrap_or_default(),
+            lfcr.as_ref().map(|stat| stat.count).unwrap_or_default(),
+        ));
+        stat
+    });
+    let cr = extract_delimiter_inner(cr, "\r").map(|mut stat| {
+        stat.count = stat.count.saturating_sub(std::cmp::max(
+            crlf.as_ref().map(|stat| stat.count).unwrap_or_default(),
+            lfcr.as_ref().map(|stat| stat.count).unwrap_or_default(),
+        ));
+        stat
+    });
+
+    // order is important, `max_by` prefers the latter ones over the earlier ones on equality
+    vec![cr, lf, crlf, lfcr]
+        .into_iter()
+        .filter_map(|x| x)
+        .max_by(|b, a| {
+            if a.count == b.count {
+                a.first_appearance.cmp(&b.first_appearance)
+            } else {
+                b.count.cmp(&a.count)
+            }
+        })
+        .map(|x| x.newline)
+}
+/*
+#[inline(always)]
+fn extract_delimiter_inner<'a>(
     mut iter: impl Iterator<Item = regex::Match<'a>>,
     newline: &'static str,
 ) -> Option<LineSepStat> {
@@ -139,6 +198,8 @@ pub fn extract_delimiter<'s>(s: &'s str) -> Option<&'static str> {
         })
         .map(|x| x.newline)
 }
+*/
+
 
 /// Reflows a parsed commonmark paragraph contained in `s`.
 ///

--- a/src/reflow/mod.rs
+++ b/src/reflow/mod.rs
@@ -82,7 +82,6 @@ fn extract_delimiter_inner<'a>(
     newline: &'static str,
 ) -> Option<LineSepStat> {
     if let Some(first) = iter.next() {
-        let first = first;
         let n = iter.count() + 1;
         Some(LineSepStat {
             first_appearance: first,
@@ -134,72 +133,6 @@ pub fn extract_delimiter<'s>(s: &'s str) -> Option<&'static str> {
         })
         .map(|x| x.newline)
 }
-/*
-#[inline(always)]
-fn extract_delimiter_inner<'a>(
-    mut iter: impl Iterator<Item = regex::Match<'a>>,
-    newline: &'static str,
-) -> Option<LineSepStat> {
-    if let Some(first) = iter.next() {
-        let first = first.start();
-        let n = iter.count() + 1;
-        Some(LineSepStat {
-            first_appearance: first,
-            count: n,
-            newline,
-        })
-    } else {
-        None
-    }
-}
-
-/// Extract line delimiter of a string.
-pub fn extract_delimiter<'s>(s: &'s str) -> Option<&'static str> {
-    use regex::Regex;
-
-    // TODO lots of room for optimizations here
-    lazy_static::lazy_static! {
-        static ref LF: Regex = Regex::new(r#"\n"#).expect("LF regex compiles. qed");
-        static ref CR: Regex = Regex::new(r#"\r"#).expect("CR regex compiles. qed");
-        static ref CRLF: Regex = Regex::new(r#"\r\n"#).expect("CRLF regex compiles. qed");
-        static ref LFCR: Regex = Regex::new(r#"\n\r"#).expect("LFCR regex compiles. qed");
-    };
-
-    // first look for two letter line delimiters
-    let lfcr = extract_delimiter_inner(LFCR.find_iter(s), "\n\r");
-    let crlf = extract_delimiter_inner(CRLF.find_iter(s), "\r\n");
-
-    // remove the 2 line line delimiters from the single line line delimiters, since they overlap
-    let lf = extract_delimiter_inner(LF.find_iter(s), "\n").map(|mut stat| {
-        stat.count = stat.count.saturating_sub(std::cmp::max(
-            crlf.as_ref().map(|stat| stat.count).unwrap_or_default(),
-            lfcr.as_ref().map(|stat| stat.count).unwrap_or_default(),
-        ));
-        stat
-    });
-    let cr = extract_delimiter_inner(CR.find_iter(s), "\r").map(|mut stat| {
-        stat.count = stat.count.saturating_sub(std::cmp::max(
-            crlf.as_ref().map(|stat| stat.count).unwrap_or_default(),
-            lfcr.as_ref().map(|stat| stat.count).unwrap_or_default(),
-        ));
-        stat
-    });
-
-    // order is important, `max_by` prefers the latter ones over the earlier ones on equality
-    vec![cr, lf, crlf, lfcr]
-        .into_iter()
-        .filter_map(|x| x)
-        .max_by(|b, a| {
-            if a.count == b.count {
-                a.first_appearance.cmp(&b.first_appearance)
-            } else {
-                b.count.cmp(&a.count)
-            }
-        })
-        .map(|x| x.newline)
-}
-*/
-
 
 /// Reflows a parsed commonmark paragraph contained in `s`.
 ///


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?
Replace Regexes with `memchr` and `memmem` in `src/reflow/mod.rs` for faster compile times (removing lazy_static) and faster performance, since `memchr` uses SIMD on x64.
Also the second commit updates the dependencies to the latest ones. Crossterm had a small API change, so I changed code in `src/action/interactive.rs`.

<!---
Delete all that do not apply:
-->
 * 🦣 Legacy
 * 🪣 Misc

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
I found a `// TODO lots of room for optimizations here` in `src/reflow/mod.rs`. There were a few Regexes, lazy compiled. I thought that the best improvement for now is replacing them with `memchr` and `memmem` since the needle is really short, 1 or 2 chars. I kept the comment just in case someone wants to optimize it even more.
## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->
13 tests do not pass the `cargo test`, but they don't do on master either, so I didn't change a thing.