### PR TITLE
refactor: improve selection ui, simplify,  add `-enclosed option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,12 @@ fn run() -> Result<ExitCode> {
 #[allow(missing_docs)]
 fn main() -> Result<()> {
     let _ = color_eyre::install()?;
-    let val = run()?.as_u8();
+    let res = run();
+    // no matter what, restore the terminal
+    if let Err(e) = action::interactive::ScopedRaw::restore_terminal() {
+        warn!("Failed to restore terminal: {}", e);
+    }
+    let val = res?.as_u8();
     if val != 0 {
         std::process::exit(val as i32)
     }


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

 * 🦚 Feature

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->

## Changes proposed by this PR:

Refactor the display code, so allowing the `\``-enclosed variant can be created easier.

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->


## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
