### PR TITLE
feat: add spellchecking to description field in Cargo.toml

### DIFF
--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = ["Bernhard Schuster <bernhard@ahoi.io>"]
 edition = "2018"
 publish = false
-description = "A silly demo with plenty of spelling mistakes for cargo-spellcheck demos and CI"
+description = "A silly demo with plenty of spelling misteakes for cargo-spellcheck demos and CI"
 readme = "README.md"
 
 [lib]

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -260,6 +260,7 @@ impl Action {
         bandaids: impl IntoIterator<Item = BandAid>,
     ) -> Result<()> {
         match origin {
+            ContentOrigin::CargoManifestDescription(path) => self.correct_file(path, bandaids),
             ContentOrigin::CommonMarkFile(path) => self.correct_file(path, bandaids),
             ContentOrigin::RustSourceFile(path) => self.correct_file(path, bandaids),
             ContentOrigin::RustDocTest(path, _span) => self.correct_file(path, bandaids),

--- a/src/documentation/chunk.rs
+++ b/src/documentation/chunk.rs
@@ -15,6 +15,8 @@ use crate::{util::sub_chars, Range, Span};
 /// Definition of the source of a checkable chunk
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum ContentOrigin {
+    /// A `Cargo.toml` manifest that contains a `description` field.
+    CargoManifestDescription(PathBuf),
     /// A common mark file at given path.
     CommonMarkFile(PathBuf),
     /// A rustdoc comment, part of file reference by path in span.
@@ -38,6 +40,7 @@ impl ContentOrigin {
     /// `/tmp/test/entity.md`.
     pub fn as_path(&self) -> &Path {
         match self {
+            Self::CargoManifestDescription(path) => path.as_path(),
             Self::CommonMarkFile(path) => path.as_path(),
             Self::RustDocTest(path, _) => path.as_path(),
             Self::RustSourceFile(path) => path.as_path(),

--- a/src/traverse/mod.rs
+++ b/src/traverse/mod.rs
@@ -551,9 +551,11 @@ pub(crate) fn extract(
                         }
                         docs.add_commonmark(ContentOrigin::CommonMarkFile(path), content.as_str())?;
                     }
-                    other => {
-                        warn!("Did not impl handling of {:?} type files", other);
-                        // TODO generate Documentation structs from non-file sources
+                    CheckEntity::ManifestDescription(path, content) => {
+                        if content.is_empty() {
+                            bail!("Cargo.toml manifest description field is empty")
+                        }
+                        docs.add_cargo_manifest_description(path, content.as_str())?;
                     }
                 }
                 Ok(docs)
@@ -609,7 +611,7 @@ mod tests {
             maplit::hashset![
                 CheckEntity::Markdown(demo_dir().join("README.md")),
                 CheckEntity::ManifestDescription(demo_dir().join("Cargo.toml"),
-                    "A silly demo with plenty of spelling mistakes for cargo-spellcheck demos and CI".to_string()
+                    "A silly demo with plenty of spelling misteakes for cargo-spellcheck demos and CI".to_string()
                 ),
             ]
         );
@@ -718,6 +720,7 @@ mod tests {
     #[test]
     fn traverse_manifest_1() {
         extract_test!(["Cargo.toml"] + false => [
+            "Cargo.toml",
             "README.md",
             "src/lib.rs",
             "src/main.rs",
@@ -752,6 +755,7 @@ mod tests {
     ]);
 
     extract_test!(traverse_manifest_dir_rec, ["."] + true => [
+        "Cargo.toml",
         "README.md",
         "src/lib.rs",
         "src/main.rs",
@@ -768,6 +772,7 @@ mod tests {
     ]);
 
     extract_test!(traverse_manifest_rec, ["Cargo.toml"] + true => [
+        "Cargo.toml",
         "README.md",
         "src/lib.rs",
         "src/main.rs",


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

Add spellchecking for `description` field in `Cargo.toml`.

I think this is a breaking change to the internal API, I'm not sure if that requires a major version bump.

<!---
Delete all that do not apply:
-->

 * 🦚 Feature

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes #233.

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particulr impl details
are wanted, state them here too.
-->

There is one test that is failing that I didn't know how to fix:

```
[2021-11-15T00:42:46Z TRACE cargo_spellcheck::traverse::tests] prefix: /Users/lopopolo/dev/repos/cargo-spellcheck/demo  --- item: /Users/lopopolo/dev/repos/cargo-spellcheck/demo/member/stray.rs
[2021-11-15T00:42:46Z TRACE cargo_spellcheck::traverse::tests] prefix: /Users/lopopolo/dev/repos/cargo-spellcheck/demo  --- item: /Users/lopopolo/dev/repos/cargo-spellcheck/demo/member/true/lib.rs
[2021-11-15T00:42:46Z TRACE cargo_spellcheck::traverse::tests] prefix: /Users/lopopolo/dev/repos/cargo-spellcheck/demo  --- item: /Users/lopopolo/dev/repos/cargo-spellcheck/demo/member/true/Cargo.toml
[2021-11-15T00:42:46Z TRACE cargo_spellcheck::traverse::tests] prefix: /Users/lopopolo/dev/repos/cargo-spellcheck/demo  --- item: /Users/lopopolo/dev/repos/cargo-spellcheck/demo/member/true/README.md
[2021-11-15T00:42:46Z TRACE cargo_spellcheck::traverse::tests] prefix: /Users/lopopolo/dev/repos/cargo-spellcheck/demo  --- item: /Users/lopopolo/dev/repos/cargo-spellcheck/demo/member/procmacro/Cargo.toml
[2021-11-15T00:42:46Z TRACE cargo_spellcheck::traverse::tests] prefix: /Users/lopopolo/dev/repos/cargo-spellcheck/demo  --- item: /Users/lopopolo/dev/repos/cargo-spellcheck/demo/member/procmacro/src/lib.rs
Left does not contain ["member/procmacro/Cargo.toml", "member/true/Cargo.toml"]
thread 'traverse::tests::traverse_dir_wo_manifest' panicked at 'assertion failed: `(left == right)`
  left: `{"member/procmacro/Cargo.toml", "member/procmacro/src/lib.rs", "member/true/README.md", "member/stray.rs", "member/true/lib.rs", "member/true/Cargo.toml"}`,
 right: `{"member/true/lib.rs", "member/true/README.md", "member/stray.rs", "member/procmacro/src/lib.rs"}`', src/traverse/mod.rs:806:5


failures:
    checker::hunspell::tests::hunspell_binding_is_sane
    traverse::tests::traverse_dir_wo_manifest

test result: FAILED. 220 passed; 2 failed; 1 ignored; 0 measured; 0 filtered out; finished in 4.51s
```

<img width="1422" alt="Screen Shot 2021-11-14 at 4 31 34 PM" src="https://user-images.githubusercontent.com/860434/141705922-9220c820-15d8-4b27-b004-44489f063b4b.png">

## 📜 Checklist

 * [ ] Works on the `./demo` sub directory
 * [ ] Test coverage is excellent and passes
 * [ ] Documentation is thorough
