### PR TITLE
work with `#[doc=foo!(..)]` style comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486d44227f71a1ef39554c0dc47e44b9f4139927c75043312690c3f476d1d788"
+checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
  "winapi",
 ]
@@ -1451,24 +1451,24 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_la-arena"
-version = "0.0.77"
+version = "0.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c126bbcc504406b874293d52d0709e8b15374ad27e769927e97f350ad862d615"
+checksum = "2c5bb16adfa02f268207bb276791321144c03ec4337d6a3733a5ff4b6d6fe9d6"
 
 [[package]]
 name = "ra_ap_parser"
-version = "0.0.77"
+version = "0.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14ece42a483836bd35f994a3b79314ac5243f53b51ef1e27e61fa2736cb0ec"
+checksum = "1169aa4087f32fcc81d7bb76435578d606ee9380f24d3b7688d07f0f168363b3"
 dependencies = [
  "drop_bomb",
 ]
 
 [[package]]
 name = "ra_ap_profile"
-version = "0.0.77"
+version = "0.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b4c9a96061967fe36356286d54fa7601c7f5e758e38b1812d4d01768cc0ea2"
+checksum = "0896d702cd4f306133533f9bfa8c9ac10e5426c15118cb26b301da64600ff617"
 dependencies = [
  "cfg-if 1.0.0",
  "countme",
@@ -1481,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_stdx"
-version = "0.0.77"
+version = "0.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0ca2bddaed8182a3f02d09e93529b6f8eebb226bb6962cd25ee2053c8b9d0f"
+checksum = "b3f040443ebe43829f5dfe63565dbe59de1e9c5e113d91319e30c2ff578c313e"
 dependencies = [
  "always-assert",
  "libc",
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_syntax"
-version = "0.0.77"
+version = "0.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a5e8065271b0599fccf4f72a7f20cb2dce2cb8846a87a8446dc17f77dab56"
+checksum = "2623419b2bbda5060c2b45861fafe175dabffada29e75bb9b7968e47f0a4d32d"
 dependencies = [
  "cov-mark",
  "indexmap",
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_text_edit"
-version = "0.0.77"
+version = "0.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724cef229171d62521a2e2794601c593c3c94baeedc3371d8f95aa658ae28404"
+checksum = "e832233b83d68af47178e6d27cec8d13a2692d69234ee369cdc41db3531c891f"
 dependencies = [
  "text-size",
 ]
@@ -1984,9 +1984,12 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "smol_str"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b203e79e90905594272c1c97c7af701533d42adaab0beb3859018e477d54a3b0"
+checksum = "61d15c83e300cce35b7c8cd39ff567c1ef42dde6d4a1a38dbdbf9a59902261bd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ rayon = "1.5"
 regex = "1.5"
 serde = { version = "1", features = ["derive"] }
 signal-hook = "0.3"
-syn = { version = "1", features = ["derive", "parsing"] }
+syn = { version = "1", features = ["full"] }
 thiserror = "1"
 # for parsing and extracting elements from Cargo.toml
 toml = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ xz2 = "0.1"
 color-eyre = "0.5"
 cargo_toml = "^0.10.1"
 console = "0.15"
-crossterm = "0.21.0"
+crossterm = "0.22.1"
 # for the config file
 directories = "4.0.1"
 docopt = "1"
@@ -45,12 +45,12 @@ log = "0.4"
 num_cpus = "1.13"
 proc-macro2 = { version = "1", features = ["span-locations"] }
 pulldown-cmark = "0.8.0"
-ra_ap_syntax = "0.0.77"
+ra_ap_syntax = "0.0.84"
 rayon = "1.5"
 regex = "1.5"
 serde = { version = "1", features = ["derive"] }
 signal-hook = "0.3"
-syn = { version = "1", features = ["full"] }
+syn = { version = "1", features = ["derive", "parsing"] }
 thiserror = "1"
 # for parsing and extracting elements from Cargo.toml
 toml = "0.5"

--- a/src/documentation/cluster.rs
+++ b/src/documentation/cluster.rs
@@ -7,7 +7,8 @@ use crate::errors::*;
 use crate::Span;
 use std::convert::TryFrom;
 
-/// Cluster literals for one file
+/// Cluster comments together, such they appear as continuous
+/// text blocks.
 #[derive(Debug)]
 pub struct Clusters {
     pub(super) set: Vec<LiteralSet>,

--- a/src/documentation/cluster.rs
+++ b/src/documentation/cluster.rs
@@ -1,21 +1,14 @@
 //! Cluster `proc_macro2::Literal`s into `LiteralSets`
 
-use syn::parse::Parse;
-use syn::parse::ParseStream;
-use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::ExprMacro;
 use syn::LitStr;
 use syn::Macro;
 use syn::Token;
-use syn::TypeMacro;
 
-use super::{trace, LiteralSet, Spacing, TokenTree, TrimmedLiteral, TryInto};
+use super::{trace, LiteralSet, TokenTree, TrimmedLiteral};
 use crate::documentation::developer::extract_developer_comments;
-use crate::documentation::Range;
 use crate::errors::*;
 use crate::Span;
-use std::convert::TryFrom;
 
 mod kw {
     syn::custom_keyword!(doc);
@@ -72,10 +65,9 @@ impl Clusters {
     /// Only works if the file is processed line by line, otherwise requires a
     /// adjacency list.
     fn process_literal(&mut self, source: &str, comment: DocComment) -> Result<()> {
-
         let span = Span::from(comment.content.span());
         let trimmed_literal = match comment.content {
-            DocContent::LitStr(s) => TrimmedLiteral::load_from(source, span)?,
+            DocContent::LitStr(_s) => TrimmedLiteral::load_from(source, span)?,
             DocContent::Macro(_) => {
                 TrimmedLiteral::new_empty(source, span, crate::CommentVariant::MacroDocEqMacro)
             }

--- a/src/documentation/cluster.rs
+++ b/src/documentation/cluster.rs
@@ -1,11 +1,65 @@
 //! Cluster `proc_macro2::Literal`s into `LiteralSets`
 
+use syn::ExprMacro;
+use syn::LitStr;
+use syn::Macro;
+use syn::Token;
+use syn::TypeMacro;
+use syn::parse::Parse;
+use syn::parse::ParseStream;
+use syn::punctuated::Punctuated;
+
 use super::{trace, LiteralSet, Spacing, TokenTree, TrimmedLiteral, TryInto};
 use crate::documentation::developer::extract_developer_comments;
 use crate::documentation::Range;
 use crate::errors::*;
 use crate::Span;
 use std::convert::TryFrom;
+
+
+mod kw {
+    syn::custom_keyword!(doc);
+}
+
+enum DocContent {
+    LitStr(LitStr),
+    Macro(Macro),
+}
+
+struct DocComment {
+    doc: kw::doc,
+    eq_token: Token![=],
+    content: DocContent,
+}
+
+impl syn::parse::Parse for DocComment {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
+        let doc = input.parse::<kw::doc>()?;
+        let eq_token: Token![=] = input.parse()?;
+
+        let lookahead = input.lookahead1();
+        let content = if lookahead.peek(LitStr) {
+            input.parse().map(DocContent::LitStr)?
+        } else {
+            input.parse().map(DocContent::Macro)?
+        };
+        Ok(Self {
+            doc,
+            eq_token,
+            content,
+        })
+    }
+}
+
+#[test]
+fn test_doc_comment_parse() {
+    let _x : DocComment = syn::parse_str(r########"doc=foo!(bar!(xxx))"########).unwrap();
+    let _x : DocComment = syn::parse_str(r########"doc="s""########).unwrap();
+    let _x : DocComment = syn::parse_str(r########"doc=r#"s"#"########).unwrap();
+    let _x : DocComment = syn::parse_str(r########"doc=r##"s"##"########).unwrap();
+    let _x : DocComment = syn::parse_str(r########"doc=r###"s"###"########).unwrap();
+    let _x : DocComment = syn::parse_str(r########"doc=r####"s"####"########).unwrap();
+}
 
 /// Cluster comments together, such they appear as continuous
 /// text blocks.
@@ -41,36 +95,9 @@ impl Clusters {
         let mut iter = stream.into_iter();
         while let Some(tree) = iter.next() {
             match tree {
-                TokenTree::Ident(ident) => {
-                    // if we find an identifier
-                    // which is doc
-                    if ident != "doc" {
-                        continue;
-                    }
 
-                    // this assures the sequence is as anticipated
-                    let op = iter.next();
-                    if op.is_none() {
-                        continue;
-                    }
-                    let op = op.unwrap();
-                    if let TokenTree::Punct(punct) = op {
-                        if punct.as_char() != '=' {
-                            continue;
-                        }
-                        if punct.spacing() != Spacing::Alone {
-                            continue;
-                        }
-                    } else {
-                        continue;
-                    }
-
-                    let comment = if let Some(comment) = iter.next() {
-                        comment
-                    } else {
-                        continue
-                    };
-
+                TokenTree::Group(group) => {
+                    self.parse_token_tree(source, dbg!(group).stream())?;
                     match comment {
                         TokenTree::Literal(literal) => {
                             let span = Span::from(literal.span());
@@ -80,13 +107,6 @@ impl Clusters {
                                 literal
                             );
 
-                            // let rendered = literal.to_string();
-                            // produces pretty unusable garabage, since it modifies the content of `///`
-                            // comments which could contain " which will be escaped
-                            // and therefor cause the `span()` to yield something that does
-                            // not align with the rendered literal at all and there are too
-                            // many pitfalls to sanitize all cases, so reading given span
-                            // from the file again, and then determining its type is way safer.
 
                             if let Err(e) = self.process_literal (source, span) {
                                 log::error!(
@@ -101,9 +121,6 @@ impl Clusters {
                             continue;
                         },
                     }
-                }
-                TokenTree::Group(group) => {
-                    self.parse_token_tree(source, group.stream())?;
                 }
                 _ => {}
             };

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -5,7 +5,7 @@ use crate::{Range, Span};
 use fancy_regex::Regex;
 use lazy_static::lazy_static;
 use proc_macro2::LineColumn;
-use std::convert::TryFrom;
+
 use std::fmt;
 
 /// Determine if a `CommentVariant`
@@ -351,7 +351,11 @@ impl TrimmedLiteral {
     /// Create an empty comment.
     ///
     /// Prime use case is for `#[doc = foo!()]` cases.
-    pub(crate) fn new_empty(content: impl AsRef<str>, span: Span, variant: CommentVariant) -> Self {
+    pub(crate) fn new_empty(
+        _content: impl AsRef<str>,
+        span: Span,
+        variant: CommentVariant,
+    ) -> Self {
         Self {
             /// Track what kind of comment the literal is
             variant,

--- a/src/documentation/literal.rs
+++ b/src/documentation/literal.rs
@@ -345,6 +345,13 @@ fn detect_comment_variant(
 impl TryFrom<(&str, Span)> for TrimmedLiteral {
     type Error = Error;
     fn try_from((content, mut span): (&str, Span)) -> Result<Self> {
+        // let rendered = literal.to_string();
+        // produces pretty unusable garabage, since it modifies the content of `///`
+        // comments which could contain " which will be escaped
+        // and therefor cause the `span()` to yield something that does
+        // not align with the rendered literal at all and there are too
+        // many pitfalls to sanitize all cases, so reading given span
+        // from the file again, and then determining its type is way safer.
 
         // It's unclear why the trailing `]` character is part of the given span, it shout not be part
         // of it, but the span we obtain from literal seems to be wrong, adding one trailing char.

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -86,8 +86,13 @@ impl LiteralSet {
                 let span = literal.span();
                 let range = Range { start, end };
 
-                if let Some(span_len) = span.one_line_len() {
-                    assert_eq!(range.len(), span_len);
+                // TODO this does not hold anymore for `#[doc=foo!(..)]`.
+                // TODO where the span is covering `foo!()`, but the
+                // TODO rendered length is 0.
+                if literal.variant() != CommentVariant::MacroDocEqMacro {
+                    if let Some(span_len) = span.one_line_len() {
+                        assert_eq!(range.len(), span_len);
+                    }
                 }
                 // keep zero length values too, to guarantee continuity
                 source_mapping.insert(range, span);

--- a/src/documentation/mod.rs
+++ b/src/documentation/mod.rs
@@ -18,9 +18,9 @@ use crate::util::load_span_from;
 use indexmap::IndexMap;
 use log::trace;
 pub use proc_macro2::LineColumn;
-use proc_macro2::{Spacing, TokenTree};
+use proc_macro2::TokenTree;
 use rayon::prelude::*;
-use std::convert::TryInto;
+
 use std::path::PathBuf;
 
 /// Range based on `usize`, simplification.

--- a/src/documentation/tests.rs
+++ b/src/documentation/tests.rs
@@ -207,6 +207,26 @@ struct X;
         );
     }
 
+
+    #[test]
+    fn issue_234() {
+        // The test
+        end2end!(
+            r####"
+/// ```
+/// use Z;
+#[doc = foo!(xyz)]
+/// struct X;
+/// ```
+struct X;
+"####,
+            ContentOrigin::TestEntityRust,
+            0,
+            DummyChecker,
+            Default::default()
+        );
+    }
+
     #[test]
     fn file_justone() {
         end2end_file_rust!("demo/src/nested/justone.rs", 2);
@@ -1260,7 +1280,8 @@ pub(crate) fn annotated_literals(source: &str) -> Vec<TrimmedLiteral> {
 
     annotated_literals_raw(source)
         .map(|literal| {
-            TrimmedLiteral::try_from((source, literal))
+            let span = Span::from(literal.span());
+            TrimmedLiteral::try_from((source, span))
                 .expect("Literals must be convertable to trimmed literals")
         })
         .collect()
@@ -1376,7 +1397,7 @@ struct Two;
                     column: 6__usize + 9,
                 },
             },
-            variant: CommentVariant::MacroDocEq("#[doc = ".to_string(), 0),
+            variant: CommentVariant::MacroDocEqStr("#[doc = ".to_string(), 0),
         },
         // 3
         Triplet {
@@ -1406,7 +1427,7 @@ struct Three;
                     column: 13__usize + 8,
                 },
             },
-            variant: CommentVariant::MacroDocEq("#[doc=".to_string(), 2),
+            variant: CommentVariant::MacroDocEqStr("#[doc=".to_string(), 2),
         },
         // 4
         Triplet {
@@ -1448,7 +1469,7 @@ lines
                     column: 0__usize,
                 },
             },
-            variant: CommentVariant::MacroDocEq("#[doc = ".to_string(), 3),
+            variant: CommentVariant::MacroDocEqStr("#[doc = ".to_string(), 3),
         },
         // 5
         Triplet {
@@ -1478,7 +1499,7 @@ struct Five;
                     column: 15_usize + 2,
                 },
             },
-            variant: CommentVariant::MacroDocEq("#[doc        =".to_string(), 0),
+            variant: CommentVariant::MacroDocEqStr("#[doc        =".to_string(), 0),
         },
         // 6
         Triplet {
@@ -1591,7 +1612,7 @@ fn unicode(&self) -> bool {
                     column: 0_usize,
                 },
             },
-            variant: CommentVariant::MacroDocEq("#[ doc = ".to_string(), 3),
+            variant: CommentVariant::MacroDocEqStr("#[ doc = ".to_string(), 3),
         },
     ];
 
@@ -1661,25 +1682,25 @@ fn raw_variant_7_unicode_symbols() {
 
 #[test]
 fn variant_to_string() {
-    let variant = CommentVariant::MacroDocEq("#[ doc = ".to_string(), 0);
+    let variant = CommentVariant::MacroDocEqStr("#[ doc = ".to_string(), 0);
     assert_eq!(variant.prefix_string(), r###"#[ doc = ""###);
-    let variant = CommentVariant::MacroDocEq("#[doc = ".to_string(), 1);
+    let variant = CommentVariant::MacroDocEqStr("#[doc = ".to_string(), 1);
     assert_eq!(variant.prefix_string(), r###"#[doc = r""###);
-    let variant = CommentVariant::MacroDocEq("#[ doc =".to_string(), 2);
+    let variant = CommentVariant::MacroDocEqStr("#[ doc =".to_string(), 2);
     assert_eq!(variant.prefix_string(), r###"#[ doc =r#""###);
-    let variant = CommentVariant::MacroDocEq("#[doc=".to_string(), 3);
+    let variant = CommentVariant::MacroDocEqStr("#[doc=".to_string(), 3);
     assert_eq!(variant.prefix_string(), r###"#[doc=r##""###);
 }
 
 #[test]
 fn variant_suffix_string() {
-    let variant = CommentVariant::MacroDocEq("#[ doc= ".to_string(), 0);
+    let variant = CommentVariant::MacroDocEqStr("#[ doc= ".to_string(), 0);
     assert_eq!(variant.suffix_string(), r###""]"###);
-    let variant = CommentVariant::MacroDocEq("#[doc = ".to_string(), 1);
+    let variant = CommentVariant::MacroDocEqStr("#[doc = ".to_string(), 1);
     assert_eq!(variant.suffix_string(), r###""]"###);
-    let variant = CommentVariant::MacroDocEq("#[doc = ".to_string(), 2);
+    let variant = CommentVariant::MacroDocEqStr("#[doc = ".to_string(), 2);
     assert_eq!(variant.suffix_string(), r###""#]"###);
-    let variant = CommentVariant::MacroDocEq("#[ doc =".to_string(), 3);
+    let variant = CommentVariant::MacroDocEqStr("#[ doc =".to_string(), 3);
     assert_eq!(variant.suffix_string(), r###""##]"###);
 }
 
@@ -1689,10 +1710,10 @@ fn variant_consistency() {
         CommentVariant::TripleSlash,
         CommentVariant::DoubleSlashEM,
         CommentVariant::CommonMark,
-        CommentVariant::MacroDocEq("#[ doc= ".to_string(), 0),
-        CommentVariant::MacroDocEq("#[doc = ".to_string(), 1),
-        CommentVariant::MacroDocEq("#[doc = ".to_string(), 2),
-        CommentVariant::MacroDocEq("#[ doc     =".to_string(), 3),
+        CommentVariant::MacroDocEqStr("#[ doc= ".to_string(), 0),
+        CommentVariant::MacroDocEqStr("#[doc = ".to_string(), 1),
+        CommentVariant::MacroDocEqStr("#[doc = ".to_string(), 2),
+        CommentVariant::MacroDocEqStr("#[ doc     =".to_string(), 3),
     ];
 
     for variant in variants {

--- a/src/documentation/tests.rs
+++ b/src/documentation/tests.rs
@@ -207,7 +207,6 @@ struct X;
         );
     }
 
-
     #[test]
     fn issue_234() {
         // The test
@@ -1281,7 +1280,7 @@ pub(crate) fn annotated_literals(source: &str) -> Vec<TrimmedLiteral> {
     annotated_literals_raw(source)
         .map(|literal| {
             let span = Span::from(literal.span());
-            TrimmedLiteral::try_from((source, span))
+            TrimmedLiteral::load_from(source, span)
                 .expect("Literals must be convertable to trimmed literals")
         })
         .collect()

--- a/src/documentation/tests.rs
+++ b/src/documentation/tests.rs
@@ -1293,10 +1293,12 @@ struct Triplet {
     /// source content
     source: &'static str,
     /// expected doc comment content without modifications
+    #[allow(dead_code)]
     extracted: &'static str,
     /// expected doc comment content after applying trimming rules
     trimmed: &'static str,
     /// expected span as extracted by proc_macro2
+    #[allow(dead_code)]
     extracted_span: Span,
     /// trimmed span, so it is aligned with the proper doc comment
     trimmed_span: Span,

--- a/src/documentation/tests.rs
+++ b/src/documentation/tests.rs
@@ -1275,8 +1275,6 @@ pub(crate) fn annotated_literals_raw<'a>(
 }
 
 pub(crate) fn annotated_literals(source: &str) -> Vec<TrimmedLiteral> {
-    use std::convert::TryFrom;
-
     annotated_literals_raw(source)
         .map(|literal| {
             let span = Span::from(literal.span());


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

Handle:
```rust
/// a
/// ```
#[doc = foo!(b)]
/// ```
/// c
struct X;
```
<!---
Delete all that do not apply:
-->

 * 🩹 Bug Fix
 * 🦚 Feature

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes #234 

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
Add a non-bearing doc-comment variant.

In a few places the assertion of a span-length being equal to the range-length had to be removed. This whole set of changes complicates the source a bit, but also provided a chance to revisit old code, that I wrote when I first leared about `syn`, so it also provided a chance to refactor that part a bit :)

## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
