### PR TITLE
quirk: disable nlprules by default

### DIFF
--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -489,7 +489,8 @@ impl Args {
         // elided, and cause even worse suggestions.
         // ISSUE: https://github.com/drahnr/cargo-spellcheck/issues/242
         let filter_set = self
-            .flag_checkers.clone()
+            .flag_checkers
+            .clone()
             .unwrap_or_else(|| vec![CheckerType::Hunspell]);
         {
             if filter_set.contains(&CheckerType::Hunspell) {

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -489,7 +489,7 @@ impl Args {
         // elided, and cause even worse suggestions.
         // ISSUE: https://github.com/drahnr/cargo-spellcheck/issues/242
         let filter_set = self
-            .flag_checkers
+            .flag_checkers.clone()
             .unwrap_or_else(|| vec![CheckerType::Hunspell]);
         {
             if filter_set.contains(&CheckerType::Hunspell) {

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -482,8 +482,16 @@ impl Args {
     fn load_config(&self) -> Result<(Config, Option<PathBuf>)> {
         let (mut config, config_path) = self.load_config_inner()?;
         // mask all disabled checkers, use the default config
-        // for those which have one if not enabled already
-        if let Some(filter_set) = &self.flag_checkers {
+        // for those which have one if not enabled already.
+
+        // FIXME: Due to an increase adoption, having `NlpRules` enabled by default,
+        // causes friction for users, especially in presence of inline codes which are
+        // elided, and cause even worse suggestions.
+        // ISSUE: https://github.com/drahnr/cargo-spellcheck/issues/242
+        let filter_set = self
+            .flag_checkers
+            .unwrap_or_else(|| vec![CheckerType::Hunspell]);
+        {
             if filter_set.contains(&CheckerType::Hunspell) {
                 if config.hunspell.is_none() {
                     config.hunspell = Some(crate::config::HunspellConfig::default());


### PR DESCRIPTION
The first experience counts, so disabling nlprules until
issue #242 is resolved, seems reasonable.

<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

 * 🩹 Bug Fix
 * 🪣 Misc

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes #240 

## Changes proposed by this PR:

Disable `nlprules` checker by default.

## Notes to reviewer:

A workaround to improve the first encounter experience. The true issue is #242 


## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
