### PR TITLE
chore: remove redundant `'static` lifetimes for `const C: &str`

### DIFF
--- a/src/action/bandaid.rs
+++ b/src/action/bandaid.rs
@@ -39,7 +39,7 @@ pub(crate) mod tests {
 
     #[test]
     fn span_helper_integrity() {
-        const SOURCE: &'static str = r#"0
+        const SOURCE: &str = r#"0
 abcde
 f
 g

--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -15,7 +15,7 @@ use crossterm::{
 
 use std::io::stdout;
 
-const HELP: &'static str = r##"y - apply this suggestion
+const HELP: &str = r##"y - apply this suggestion
 n - do not apply the suggested correction
 q - quit; do not stage this hunk or any of the remaining ones
 d - do not apply this suggestion and skip the rest of the file

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -285,7 +285,7 @@ impl Action {
 
         let mut reader = std::io::BufReader::new(ro);
 
-        const TEMPORARY: &'static str = ".spellcheck.tmp";
+        const TEMPORARY: &str = ".spellcheck.tmp";
 
         // Avoid issues when processing multiple files in parallel
         let tmp_name = TEMPORARY.to_owned() + uuid::Uuid::new_v4().to_string().as_str();

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -131,7 +131,7 @@ pub mod tests {
 
     use crate::fluff_up;
 
-    const TEXT: &'static str = "With markdown removed, for sure.";
+    const TEXT: &str = "With markdown removed, for sure.";
     lazy_static::lazy_static! {
         static ref TOKENS: Vec<&'static str> = vec![
             "With",
@@ -189,7 +189,7 @@ pub mod tests {
 
     #[test]
     fn extract_suggestions_simple() {
-        const SIMPLE: &'static str = fluff_up!("two literals");
+        const SIMPLE: &str = fluff_up!("two literals");
 
         /// keep in mind, `Span` bounds are inclusive, unlike Ranges, where
         /// `range.end` is _exclusive_
@@ -211,7 +211,7 @@ pub mod tests {
 
     #[test]
     fn extract_suggestions_left_aligned() {
-        const SIMPLE: &'static str = fluff_up!("two  literals ");
+        const SIMPLE: &str = fluff_up!("two  literals ");
 
         /// keep in mind, `Span` bounds are inclusive, unlike Ranges, where
         /// `range.end` is _exclusive_
@@ -233,7 +233,7 @@ pub mod tests {
 
     #[test]
     fn extract_suggestions_3spaces() {
-        const SIMPLE: &'static str = fluff_up!("  third  testcase ");
+        const SIMPLE: &str = fluff_up!("  third  testcase ");
 
         /// keep in mind, `Span` bounds are inclusive, unlike Ranges, where
         /// `range.end` is _exclusive_

--- a/src/checker/quirks.rs
+++ b/src/checker/quirks.rs
@@ -157,7 +157,7 @@ mod tests {
             .try_init();
 
         const REPLACEMENTS: &'static [&'static str] = &["fffff", "qqq", "z", "zeta-ray"];
-        const WORD: &'static str = "zetaray";
+        const WORD: &str = "zetaray";
         assert!(replacements_contain_dashed(WORD, REPLACEMENTS));
     }
 
@@ -168,7 +168,7 @@ mod tests {
             .filter(None, log::LevelFilter::Trace)
             .try_init();
 
-        const WORD: &'static str = "zeta-ray";
+        const WORD: &str = "zeta-ray";
         const REPLACEMENTS: &'static [&'static str] = &["fffff", "qqq", "z", "zetaray"];
         assert!(replacements_contain_dashless(WORD, REPLACEMENTS));
     }

--- a/src/documentation/literalset.rs
+++ b/src/documentation/literalset.rs
@@ -200,16 +200,16 @@ pub(crate) mod tests {
 
     #[test]
     fn fluff_one() {
-        const RAW: &'static str = fluff_up!(["a"]);
-        const EXPECT: &'static str = r#"/// a
+        const RAW: &str = fluff_up!(["a"]);
+        const EXPECT: &str = r#"/// a
 struct Fluff;"#;
         assert_eq!(RAW, EXPECT);
     }
 
     #[test]
     fn fluff_multi() {
-        const RAW: &'static str = fluff_up!(["a", "b", "c"]);
-        const EXPECT: &'static str = r#"/// a
+        const RAW: &str = fluff_up!(["a", "b", "c"]);
+        const EXPECT: &str = r#"/// a
 /// b
 /// c
 struct Fluff;"#;

--- a/src/documentation/tests.rs
+++ b/src/documentation/tests.rs
@@ -306,18 +306,18 @@ struct X;
     #[test]
     fn word_extraction_rust() {
         // raw source
-        const SOURCE: &'static str = r#"/// A headline.
+        const SOURCE: &str = r#"/// A headline.
 ///
 /// Erronbeous **bold** __uetchkp__
 struct X"#;
 
         // extracted content as present as provided by `chunk.as_str()`
-        const RAW: &'static str = r#" A headline.
+        const RAW: &str = r#" A headline.
 
  Erronbeous **bold** __uetchkp__"#;
 
         // markdown erased residue
-        const PLAIN: &'static str = r#"A headline.
+        const PLAIN: &str = r#"A headline.
 
 Erronbeous bold uetchkp"#;
 
@@ -334,16 +334,16 @@ Erronbeous bold uetchkp"#;
     #[test]
     fn word_extraction_commonmark_small() {
         // raw source
-        const SOURCE: &'static str = r###"## cmark test 1
+        const SOURCE: &str = r###"## cmark test 1
 
 🐢 are _so_ *cute*!
 "###;
 
         // extracted content as present as provided by `chunk.as_str()`
-        const RAW: &'static str = SOURCE;
+        const RAW: &str = SOURCE;
 
         // markdown erased residue
-        const PLAIN: &'static str = r##"cmark test 1
+        const PLAIN: &str = r##"cmark test 1
 
 🐢 are so cute!"##;
 
@@ -367,7 +367,7 @@ Erronbeous bold uetchkp"#;
     #[test]
     fn word_extraction_commonmark_large() {
         // raw source
-        const SOURCE: &'static str = r#"# cmark test
+        const SOURCE: &str = r#"# cmark test
 
 <pre>🌡</pre>
 
@@ -386,10 +386,10 @@ let code = be;
 The end.🐢"#;
 
         // extracted content as present as provided by `chunk.as_str()`
-        const RAW: &'static str = SOURCE;
+        const RAW: &str = SOURCE;
 
         // markdown erased residue
-        const PLAIN: &'static str = r#"cmark test
+        const PLAIN: &str = r#"cmark test
 
 A relly boring test.
 
@@ -431,7 +431,7 @@ The end.🐢"#;
         // TODO FIXME remove the 🍁, and observe early termination
 
         // raw source
-        const SOURCE: &'static str = r#"A
+        const SOURCE: &str = r#"A
 x🌡  in 🍁
 
 ---
@@ -439,10 +439,10 @@ x🌡  in 🍁
 Ef gh"#;
 
         // extracted content as present as provided by `chunk.as_str()`
-        const RAW: &'static str = SOURCE;
+        const RAW: &str = SOURCE;
 
         // markdown erased residue
-        const PLAIN: &'static str = r#"A
+        const PLAIN: &str = r#"A
 x🌡  in 🍁
 
 
@@ -468,7 +468,7 @@ Ef gh"#;
         // TODO FIXME remove the 🍁, and observe early termination
 
         // raw source
-        const SOURCE: &'static str = r#"
+        const SOURCE: &str = r#"
 Ref1
 
 🌡🍁
@@ -485,10 +485,10 @@ Ref4
 "#;
 
         // extracted content as present as provided by `chunk.as_str()`
-        const RAW: &'static str = SOURCE;
+        const RAW: &str = SOURCE;
 
         // markdown erased residue
-        const PLAIN: &'static str = r#"Ref1
+        const PLAIN: &str = r#"Ref1
 
 🌡🍁
 
@@ -548,7 +548,7 @@ fn find_spans_simple() {
         .try_init();
 
     // generate  `///<space>...`
-    const SOURCE: &'static str = fluff_up!(["xyz"]);
+    const SOURCE: &str = fluff_up!(["xyz"]);
     let set = gen_literal_set(SOURCE);
     let chunk = dbg!(CheckableChunk::from_literalset(set));
 
@@ -587,7 +587,7 @@ fn find_spans_multiline() {
         .filter(None, log::LevelFilter::Trace)
         .try_init();
 
-    const SOURCE: &'static str = fluff_up!(["xyz", "second", "third", "Converts a span to a range, where `self` is converted to a range reltive to the",
+    const SOURCE: &str = fluff_up!(["xyz", "second", "third", "Converts a span to a range, where `self` is converted to a range reltive to the",
          "passed span `scope`."] @ "       "
     );
     let set = gen_literal_set(SOURCE);
@@ -671,7 +671,7 @@ fn find_spans_chyrp() {
         .filter(None, log::LevelFilter::Trace)
         .try_init();
 
-    const SOURCE: &'static str = chyrp_up!(["Amsel", "Wacholderdrossel", "Buchfink"]);
+    const SOURCE: &str = chyrp_up!(["Amsel", "Wacholderdrossel", "Buchfink"]);
     let set = gen_literal_set(SOURCE);
     let chunk = dbg!(CheckableChunk::from_literalset(set));
 
@@ -724,7 +724,7 @@ fn find_spans_inclusive() {
         .is_test(true)
         .try_init();
 
-    const SOURCE: &'static str = fluff_up!(["Some random words"]);
+    const SOURCE: &str = fluff_up!(["Some random words"]);
     let set = gen_literal_set(SOURCE);
     let chunk = dbg!(CheckableChunk::from_literalset(set));
     // a range inside the span
@@ -760,7 +760,7 @@ fn find_spans_and_coverage_integrity() -> Result<()> {
         .is_test(true)
         .try_init();
 
-    const SOURCE: &'static str = fluff_up!(
+    const SOURCE: &str = fluff_up!(
         [
             "ü×ä×ß",
             "DEF_HIJ",
@@ -820,7 +820,7 @@ fn find_coverage_multiline() {
         .is_test(true)
         .try_init();
 
-    const SOURCE: &'static str = fluff_up!(
+    const SOURCE: &str = fluff_up!(
         [
             "xyz",
             "second",
@@ -876,7 +876,7 @@ fn find_coverage_multiline() {
 
 #[test]
 fn find_line_lengths_tripple_slash() {
-    const SOURCE: &'static str = fluff_up!(
+    const SOURCE: &str = fluff_up!(
         [
             "xyz",
             "second",
@@ -912,7 +912,7 @@ fn find_line_lengths_tripple_slash() {
 #[test]
 #[ignore = "prefix and suffix are not part of the accounted `extract_lines_lengths"]
 fn find_line_length_docmacro() {
-    const SOURCE: &'static str = chyrp_up!(
+    const SOURCE: &str = chyrp_up!(
         [
             "xyz",
             "second",

--- a/src/reflow/iter.rs
+++ b/src/reflow/iter.rs
@@ -345,21 +345,21 @@ mod tests {
 
         #[test]
         fn smilies() {
-            const CONTENT: &'static str = "🍇🌡 🌤";
+            const CONTENT: &str = "🍇🌡 🌤";
             const EXPECTED: &[&'static str] = &["🍇🌡", "🌤"];
             verify(CONTENT, EXPECTED, vec![0..2]);
         }
 
         #[test]
         fn multi_char() {
-            const CONTENT: &'static str = "abc xyz qwert";
+            const CONTENT: &str = "abc xyz qwert";
             const EXPECTED: &[&'static str] = &["abc", "xyz", "qwert"];
             verify(CONTENT, EXPECTED, vec![]);
         }
 
         #[test]
         fn partial_covered_word_unbreakable() {
-            const CONTENT: &'static str = "abc xyz qwert";
+            const CONTENT: &str = "abc xyz qwert";
             const EXPECTED: &[&'static str] = &["abc xyz", "qwert"];
             verify(CONTENT, EXPECTED, vec![2..5]);
         }
@@ -369,15 +369,15 @@ mod tests {
         use super::*;
         #[test]
         fn wrap_too_long_fluid() {
-            const CONTENT: &'static str = "something kinda too long for a single line";
-            const EXPECTED: &'static str = r#"something kinda too long for a
+            const CONTENT: &str = "something kinda too long for a single line";
+            const EXPECTED: &str = r#"something kinda too long for a
 single line"#;
             verify_reflow(CONTENT, EXPECTED, 30usize, vec![], vec![0]);
         }
 
         #[test]
         fn wrap_too_short_fluid() {
-            const CONTENT: &'static str = r#"something
+            const CONTENT: &str = r#"something
 kinda
 too
 short
@@ -386,7 +386,7 @@ a
 single
 line"#;
 
-            const EXPECTED: &'static str = r#"something kinda too short for
+            const EXPECTED: &str = r#"something kinda too short for
 a single line"#;
 
             verify_reflow(CONTENT, EXPECTED, 30usize, vec![], vec![0; 8]);
@@ -394,31 +394,31 @@ a single line"#;
 
         #[test]
         fn wrap_just_fine() {
-            const CONTENT: &'static str = r#"just fine, no action required 🐱"#;
-            const EXPECTED: &'static str = CONTENT;
+            const CONTENT: &str = r#"just fine, no action required 🐱"#;
+            const EXPECTED: &str = CONTENT;
 
             verify_reflow(CONTENT, EXPECTED, 40usize, vec![], vec![0]);
         }
 
         #[test]
         fn wrap_too_long_unbreakable() {
-            const CONTENT: &'static str = "something kinda too Xong for a singlX line";
-            const EXPECTED: &'static str = r#"something kinda too
+            const CONTENT: &str = "something kinda too Xong for a singlX line";
+            const EXPECTED: &str = r#"something kinda too
 Xong for a singlX line"#;
             verify_reflow(CONTENT, EXPECTED, 30usize, vec![20..37], vec![0]);
         }
 
         #[test]
         fn spaces_and_tabs() {
-            const CONTENT: &'static str = "        something     kinda       ";
-            const EXPECTED: &'static str = r#"something kinda"#;
+            const CONTENT: &str = "        something     kinda       ";
+            const EXPECTED: &str = r#"something kinda"#;
             verify_reflow(CONTENT, EXPECTED, 20usize, vec![], vec![0]);
         }
 
         #[test]
         fn deep_indentation_too_long() {
-            const CONTENT: &'static str = r#"deep indentation"#;
-            const EXPECTED: &'static str = r#"deep
+            const CONTENT: &str = r#"deep indentation"#;
+            const EXPECTED: &str = r#"deep
 indentation"#;
             // 20 < 31 = 4 + 1 + 11 + 15
             verify_reflow(CONTENT, EXPECTED, 20usize, vec![], vec![15]);
@@ -431,9 +431,9 @@ indentation"#;
                 .filter(None, log::LevelFilter::Trace)
                 .try_init();
 
-            const CONTENT: &'static str = r#"deep
+            const CONTENT: &str = r#"deep
 indentation"#;
-            const EXPECTED: &'static str = r#"deep indentation"#;
+            const EXPECTED: &str = r#"deep indentation"#;
             // 22 > 21 = 4 + 1 + 11 + 5
             verify_reflow(CONTENT, EXPECTED, 22usize, vec![], vec![5, 5]);
         }

--- a/src/reflow/tests.rs
+++ b/src/reflow/tests.rs
@@ -12,7 +12,7 @@ macro_rules! verify_reflow_inner {
             .is_test(true)
             .try_init();
 
-        const CONTENT: &'static str = fluff_up!($( $line ),+);
+        const CONTENT: &str = fluff_up!($( $line ),+);
         let docs = Documentation::load_from_str(ContentOrigin::TestEntityRust, CONTENT, false);
         assert_eq!(docs.entry_count(), 1);
         let chunks = docs.get(&ContentOrigin::TestEntityRust).expect("Must contain dummy path");
@@ -274,12 +274,12 @@ fn reflow_indentations() {
         .is_test(true)
         .try_init();
 
-    const CONTENT: &'static str = r#"
+    const CONTENT: &str = r#"
     /// 🔴 🍁
     /// 🤔
     struct Fluffy {};"#;
 
-    const EXPECTED: &'static str = r#"🔴
+    const EXPECTED: &str = r#"🔴
     /// 🍁
     /// 🤔"#;
 
@@ -315,13 +315,13 @@ fn reflow_indentations() {
 
 #[test]
 fn reflow_doc_indentations() {
-    const CONTENT: &'static str = r##"
+    const CONTENT: &str = r##"
     #[doc = r#"A comment with indentation that spans over
                 two lines and should be rewrapped.
             "#]
     struct Fluffy {};"##;
 
-    const EXPECTED: &'static str = r##"A comment with indentation"#]
+    const EXPECTED: &str = r##"A comment with indentation"#]
     #[doc = r#"that spans over two lines and"#]
     #[doc = r#"should be rewrapped."##;
 
@@ -381,8 +381,7 @@ fn reflow_split_one_into_three() {
 
 #[test]
 fn reflow_markdown_two_paragraphs() {
-    const CONTENT: &'static str =
-        "/// Possible __ways__ to run __rustc__ and request various parts of LTO.
+    const CONTENT: &str = "/// Possible __ways__ to run __rustc__ and request various parts of LTO.
 ///
 /// Some more text after the newline which **represents** a paragraph";
 
@@ -492,8 +491,7 @@ fn reflow_sole_markdown() {
         max_line_length: 60,
     };
 
-    const CONTENT: &'static str =
-        "# Possible __ways__ to run __rustc__ and request various parts of LTO.
+    const CONTENT: &str = "# Possible __ways__ to run __rustc__ and request various parts of LTO.
 
 A short line but long enough such that we reflow it. Yada lorem ipsum stuff needed.
 
@@ -595,7 +593,7 @@ fn reflow_check_span() {
         max_line_length: 27,
     };
 
-    const CONTENT: &'static str = "/// A comment as we have many here and we will always
+    const CONTENT: &str = "/// A comment as we have many here and we will always
 /// have.
 struct Fff;
 ";
@@ -630,7 +628,7 @@ struct Fff;
 #[test]
 fn reflow_readme() {
     // TODO reduce this to the minimal failing test case
-    const README: &'static str = include_str!("../../README.md");
+    const README: &str = include_str!("../../README.md");
 
     reflow_content!(80usize break ContentOrigin::TestEntityCommonMark, README => ok);
 }
@@ -660,7 +658,7 @@ Yada
 "# ] );
 }
 
-const MINIFIED_README: &'static str = r###"# cargo-spellcheck
+const MINIFIED_README: &str = r###"# cargo-spellcheck
 
 [![crates.io](https://img.source/cargo_spellcheck.svg)](https://crates.io)
 
@@ -723,7 +721,7 @@ of `0`.
 
 #[test]
 fn reflow_crlf() {
-    const INPUT: &'static str = "        /// cargo spellcheck can be configured with `-m <code>` to return a non-zero return code.\r\n        struct Foo {}";
+    const INPUT: &str = "        /// cargo spellcheck can be configured with `-m <code>` to return a non-zero return code.\r\n        struct Foo {}";
     println!("{:?}", INPUT);
     reflow_content!(40usize break ContentOrigin::TestEntityRust, INPUT
     => patches [

--- a/src/span.rs
+++ b/src/span.rs
@@ -293,7 +293,7 @@ mod tests {
             .filter(None, log::LevelFilter::Trace)
             .try_init();
 
-        const CONTENT: &'static str = fluff_up!("Itsyou!!", " ", "Game-Over!!", " ");
+        const CONTENT: &str = fluff_up!("Itsyou!!", " ", "Game-Over!!", " ");
         let set = gen_literal_set(CONTENT);
         let chunk = dbg!(CheckableChunk::from_literalset(set));
 
@@ -366,7 +366,7 @@ mod tests {
             .try_init();
 
         chyrp_dbg!("Xy fff?? Not.., you again!", "", "AlphaOmega", "");
-        const CONTENT: &'static str = chyrp_up!("Xy fff?? Not.., you again!", "", "AlphaOmega", "");
+        const CONTENT: &str = chyrp_up!("Xy fff?? Not.., you again!", "", "AlphaOmega", "");
         let set = gen_literal_set(dbg!(CONTENT));
         let chunk = dbg!(CheckableChunk::from_literalset(set));
 
@@ -449,7 +449,7 @@ AlphaOmega
 
     #[test]
     fn extraction_fluff() {
-        const CHUNK_S: &'static str = r#" one
+        const CHUNK_S: &str = r#" one
  two
  three"#;
         const FRAGMENT_SPAN: Span = Span {
@@ -475,7 +475,7 @@ AlphaOmega
 
     #[test]
     fn extraction_chyrp() {
-        const CHUNK_S: &'static str = r#"one
+        const CHUNK_S: &str = r#"one
 two
 three"#;
         const FRAGMENT_SPAN: Span = Span {

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -124,10 +124,10 @@ pub fn condition_display_content(
     const HEAD_DISPLAY_LEN: usize = 4;
     const TAIL_DISPLAY_LEN: usize = 4;
 
-    const CENTER_DOTS: &'static str = "...";
-    const LEFT_DOTS: &'static str = "..";
-    const RIGHT_DOTS: &'static str = LEFT_DOTS;
-    const NO_DOTS: &'static str = "";
+    const CENTER_DOTS: &str = "...";
+    const LEFT_DOTS: &str = "..";
+    const RIGHT_DOTS: &str = LEFT_DOTS;
+    const NO_DOTS: &str = "";
 
     // guarantees that `marker_size` is always less than the max length.
     assert!(HEAD_DISPLAY_LEN + CENTER_DOTS.len() + TAIL_DISPLAY_LEN <= MAX_MISTAKE_LEN);
@@ -706,7 +706,7 @@ mod tests {
 
     #[test]
     fn fmt_0_single() {
-        const CONTENT: &'static str = " Is it dyrck again?";
+        const CONTENT: &str = " Is it dyrck again?";
         let chunk = CheckableChunk::from_str(
             CONTENT,
             indexmap::indexmap! { 0..18 => Span {
@@ -743,7 +743,7 @@ mod tests {
             description: Some("Possible spelling mistake found.".to_owned()),
         };
 
-        const EXPECTED: &'static str = r#"error: spellcheck(Dummy)
+        const EXPECTED: &str = r#"error: spellcheck(Dummy)
   --> /tmp/test/entity.rs:1
    |
  1 |  Is it dyrck again?
@@ -757,7 +757,7 @@ mod tests {
 
     #[test]
     fn fmt_0_no_suggestion() {
-        const CONTENT: &'static str = " Is it dyrck again?";
+        const CONTENT: &str = " Is it dyrck again?";
         let chunk = CheckableChunk::from_str(
             CONTENT,
             indexmap::indexmap! { 0..18 => Span {
@@ -790,7 +790,7 @@ mod tests {
             description: Some("Possible spelling mistake found.".to_owned()),
         };
 
-        const EXPECTED: &'static str = r#"error: spellcheck(Dummy)
+        const EXPECTED: &str = r#"error: spellcheck(Dummy)
   --> /tmp/test/entity.rs:1
    |
  1 |  Is it dyrck again?
@@ -802,7 +802,7 @@ mod tests {
 
     #[test]
     fn fmt_1_multi() {
-        const CONTENT: &'static str = r#" Line mitake 1
+        const CONTENT: &str = r#" Line mitake 1
  Anowher 2
  Last"#;
 
@@ -866,7 +866,7 @@ mod tests {
             description: Some("Possible spelling mistake found.".to_owned()),
         };
 
-        const EXPECTED: &'static str = r#"error: spellcheck(Dummy)
+        const EXPECTED: &str = r#"error: spellcheck(Dummy)
   --> /tmp/test/entity.rs:1
    |
  1 |  Line mitake 1
@@ -881,7 +881,7 @@ mod tests {
 
     #[test]
     fn fmt_2_multi_80_plus() {
-        const CONTENT: &'static str = r#" Line mitake 1
+        const CONTENT: &str = r#" Line mitake 1
  Suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuper duuuuuuuuuuuuuuuuuuuuuuuuper too long
  "#;
 
@@ -932,7 +932,7 @@ mod tests {
             description: Some("Possible spelling mistake found.".to_owned()),
         };
 
-        const EXPECTED: &'static str = r#"error: spellcheck(Dummy)
+        const EXPECTED: &str = r#"error: spellcheck(Dummy)
   --> /tmp/test/entity.rs:2
    |
  2 | ..uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuper duuu...uper too long

--- a/src/util.rs
+++ b/src/util.rs
@@ -272,11 +272,11 @@ mod tests {
     }
     #[test]
     fn iter_chars() {
-        const S: &'static str = r#"
+        const S: &str = r#"
 abc
 d
 "#;
-        const S2: &'static str = r#"c
+        const S2: &str = r#"c
 d"#;
         const EXPECT: &[(LineColumn, char)] = &[
             lcc!(1, 0, '\n'),
@@ -308,10 +308,10 @@ d"#;
 
     #[test]
     fn iter_span_doc_0_trivial() {
-        const SOURCE: &'static str = r##"#[doc=r#"Zebra
+        const SOURCE: &str = r##"#[doc=r#"Zebra
 Schlupfwespe,
 Grünfink"#]"##;
-        const S2: &'static str = r#"Zebra
+        const S2: &str = r#"Zebra
 Schlupfwespe,
 Grünfink"#;
 
@@ -331,10 +331,10 @@ Grünfink"#;
 
     #[test]
     fn iter_span_doc_1_trailing_newline() {
-        const SOURCE: &'static str = r##"#[doc=r#"Zebra
+        const SOURCE: &str = r##"#[doc=r#"Zebra
 Schlupfwespe,
 "#]"##;
-        const S2: &'static str = r#"Zebra
+        const S2: &str = r#"Zebra
 Schlupfwespe,
 "#;
 
@@ -357,8 +357,8 @@ Schlupfwespe,
 
     #[test]
     fn sub_a() {
-        const A: &'static str = "a🐲o🌡i🡴f🕧aodnferntkng";
-        const A_EXPECTED: &'static str = "a🐲o";
+        const A: &str = "a🐲o🌡i🡴f🕧aodnferntkng";
+        const A_EXPECTED: &str = "a🐲o";
 
         assert_eq!(sub_char_range(A, 0..3), A_EXPECTED);
         assert_eq!(sub_char_range(A, ..3), A_EXPECTED);
@@ -367,8 +367,8 @@ Schlupfwespe,
 
     #[test]
     fn sub_b() {
-        const B: &'static str = "fff🦦🡴🕧";
-        const B_EXPECTED: &'static str = "🦦🡴🕧";
+        const B: &str = "fff🦦🡴🕧";
+        const B_EXPECTED: &str = "🦦🡴🕧";
 
         assert_eq!(sub_char_range(B, 3..=5), B_EXPECTED);
         assert_eq!(sub_char_range(B, 3..), B_EXPECTED);
@@ -376,8 +376,8 @@ Schlupfwespe,
 
     #[test]
     fn sub_c() {
-        const B: &'static str = "fff🦦🡴🕧";
-        const B_EXPECTED: &'static str = "";
+        const B: &str = "fff🦦🡴🕧";
+        const B_EXPECTED: &str = "";
 
         assert_eq!(sub_char_range(B, 10..), B_EXPECTED);
         assert_eq!(sub_char_range(B, 15..16), B_EXPECTED);


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

Prepare for a `cargo clippy` pass, to be less verbose. Currently there are many warnings and hard errors are hard to find.

<!---
Delete all that do not apply:
-->

 * 🪣 Misc

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->


## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
