### PR TITLE
Fix "Remedies" link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ the first time!
 ## Documentation
 
 - [Features and Roadmap](docs/features.md)
-- [Remedies for common issues](docs/remedies.md)
+- [Remedies for common issues](docs/remedy.md)
 - [Configuration](docs/configuration.md)
 - [Available Checkers](docs/checkers.md)
 - [Automation of `cargo-spellcheck`](docs/automation.md)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?


 * 📙 Documentation
## Changes proposed by this PR:
Fix the broken link in the root `README.md`
## Notes to reviewer:
This just fixes this particular link. #175 would likely have caught this.


## 📜 Checklist

 * [x] ~Works on the `./demo` sub directory~
 * [x] ~Test coverage is excellent and passes~
 * [x] ~Documentation is thorough~
