### PR TITLE
update ra_ap_syntax and cleanup dev comments parsing a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "countme"
-version = "2.0.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328b822bdcba4d4e402be8d9adb6eebf269f969f8eadef977a553ff3c4fbcb58"
+checksum = "03746e0c6dd9b5d2d9132ffe0bede35fb5f815604fd371bb42599fd37bc8e483"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -1132,7 +1132,7 @@ checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
- "miow",
+ "miow 0.3.7",
  "ntapi",
  "winapi",
 ]
@@ -1144,6 +1144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7377f7792b3afb6a3cba68daa54ca23c032137010460d667fda53a8d66be00e"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1423,24 +1432,32 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_la-arena"
-version = "0.0.84"
+version = "0.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5bb16adfa02f268207bb276791321144c03ec4337d6a3733a5ff4b6d6fe9d6"
+checksum = "68210d8f8aa9c49d909160219ab7b49af310c4f882a990ed6c72e5ed34e46a45"
+
+[[package]]
+name = "ra_ap_limit"
+version = "0.0.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bdd64ec27edcd76d48f75197c22f4391180834259534170fa5b2a7b9446b55"
 
 [[package]]
 name = "ra_ap_parser"
-version = "0.0.84"
+version = "0.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1169aa4087f32fcc81d7bb76435578d606ee9380f24d3b7688d07f0f168363b3"
+checksum = "953dc093827b2c9fe21a8a58aa7fbf552abdab321ff215696b0ea1ab3a629257"
 dependencies = [
  "drop_bomb",
+ "ra_ap_limit",
+ "rustc-ap-rustc_lexer",
 ]
 
 [[package]]
 name = "ra_ap_profile"
-version = "0.0.84"
+version = "0.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0896d702cd4f306133533f9bfa8c9ac10e5426c15118cb26b301da64600ff617"
+checksum = "45e855d8fd8277667445d4c94e5dc8aa3ed206542e389c6b09e9a9a318239d1e"
 dependencies = [
  "cfg-if 1.0.0",
  "countme",
@@ -1453,21 +1470,21 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_stdx"
-version = "0.0.84"
+version = "0.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f040443ebe43829f5dfe63565dbe59de1e9c5e113d91319e30c2ff578c313e"
+checksum = "e28d9cfd8dd41c91748b1c012dd48598ba2889fb96835b1aee9bd5d798ad6506"
 dependencies = [
  "always-assert",
  "libc",
- "miow",
+ "miow 0.4.0",
  "winapi",
 ]
 
 [[package]]
 name = "ra_ap_syntax"
-version = "0.0.84"
+version = "0.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2623419b2bbda5060c2b45861fafe175dabffada29e75bb9b7968e47f0a4d32d"
+checksum = "12c071dfd618b6d017e756d5e59bc4d2c78ee72e17b6e25bd8d15604e1a82f73"
 dependencies = [
  "cov-mark",
  "indexmap",
@@ -1485,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_text_edit"
-version = "0.0.84"
+version = "0.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e832233b83d68af47178e6d27cec8d13a2692d69234ee369cdc41db3531c891f"
+checksum = "d51f2b81658a496db491cfc4947f301ed0d269b544efb589075266a596a5d992"
 dependencies = [
  "text-size",
 ]
@@ -1617,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.14.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f77412a3d1f26af0c0783c23b3555a301b1a49805cba7bf9a7827a9e9e285f0"
+checksum = "71ea8fec43656b71f8bf4a0351ab18604488ee13b0bf72cad2965f5bb2ca9dc6"
 dependencies = [
  "countme",
  "hashbrown",
@@ -2355,6 +2372,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ca39602d5cbfa692c4b67e3bcbb2751477355141c1ed434c94da4186836ff6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52695a41e536859d5308cc613b4a022261a274390b25bd29dfff4bf08505f3c2"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54725ac23affef038fecb177de6c9bf065787c2f432f79e3c373da92f3e1d8a"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d5158a43cc43623c0729d1ad6647e62fa384a3d135fd15108d37c683461f64"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc31f409f565611535130cfe7ee8e6655d3fa99c1c61013981e491921b5ce954"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2b8c7cbd3bfdddd9ab98769f9746a7fad1bca236554cd032b78d768bc0e89f"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ log = "0.4"
 num_cpus = "1.13"
 proc-macro2 = { version = "1", features = ["span-locations"] }
 pulldown-cmark = "0.9.0"
-ra_ap_syntax = "0.0.84"
+ra_ap_syntax = "0.0.90"
 rayon = "1.5"
 regex = "1.5"
 serde = { version = "1", features = ["derive"] }

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -524,7 +524,7 @@ impl Args {
                     None if self.flag_stdout => ConfigWriteDestination::Stdout,
                     Some(path) => ConfigWriteDestination::File {
                         overwrite: self.flag_force,
-                        path: path.to_owned(),
+                        path,
                     },
                     None if self.flag_user => ConfigWriteDestination::File {
                         overwrite: self.flag_force,

--- a/src/documentation/cluster.rs
+++ b/src/documentation/cluster.rs
@@ -117,9 +117,7 @@ impl Clusters {
     /// and adds them to this `Clusters`
     fn parse_developer_comments(&mut self, source: &str) {
         let developer_comments = extract_developer_comments(source);
-        for comment in developer_comments {
-            self.set.push(comment);
-        }
+        self.set.extend(developer_comments.into_iter());
     }
 
     /// Sort the `LiteralSet`s in this `Cluster` by start line descending, to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,10 +213,9 @@ pub fn run() -> Result<ExitCode> {
             let finish = rt.block_on(async move { action.run(documents, config).await })?;
 
             match finish {
-                Finish::MistakeCount(0) => Ok(ExitCode::Success),
+                Finish::Success | Finish::MistakeCount(0) => Ok(ExitCode::Success),
                 Finish::MistakeCount(_n) => Ok(ExitCode::Custom(exit_code_override)),
                 Finish::Abort => Ok(ExitCode::Signal),
-                Finish::Success => Ok(ExitCode::Success),
             }
         }
     }

--- a/src/traverse/mod.rs
+++ b/src/traverse/mod.rs
@@ -456,12 +456,10 @@ pub(crate) fn extract(
                     match fs::read_dir(path) {
                         Err(err) => warn!("Listing directory contents {} failed", err),
                         Ok(entries) => {
-                            for entry in entries {
-                                if let Ok(entry) = entry {
-                                    let path = entry.path();
-                                    // let's try with that path again
-                                    flow.push_back(path);
-                                }
+                            for entry in entries.flatten() {
+                                let path = entry.path();
+                                // let's try with that path again
+                                flow.push_back(path);
                             }
                         }
                     }
@@ -470,14 +468,12 @@ pub(crate) fn extract(
                     match fs::read_dir(path) {
                         Err(err) => warn!("Listing directory contents {} failed", err),
                         Ok(entries) => {
-                            for entry in entries {
-                                if let Ok(entry) = entry {
-                                    let path = entry.path();
-                                    // let's try attempt with that .rs file
-                                    // if we end up here, recursion is off already
-                                    if path.is_file() {
-                                        flow.push_back(path);
-                                    }
+                            for entry in entries.flatten() {
+                                let path = entry.path();
+                                // let's try attempt with that .rs file
+                                // if we end up here, recursion is off already
+                                if path.is_file() {
+                                    flow.push_back(path);
                                 }
                             }
                         }


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

Update `ra_ap_syntax` which required to rethink the impl. Prepares for the custom `syn` backend removal, once `#[doc=foo!()]` macros work with this backend (untested).

 * 🦚 Feature

## Changes proposed by this PR:

Update `ra_ap_syntax` and prep for parsing unification

## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
