### PR TITLE
Fix HTML used in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,13 @@ systems.
 cargo spellcheck check
 ```
 
-<pre><font color="#CC0000"><b>error</b></font><font color="#D3D7CF"><b>: spellcheck</b></font>
-<font color="#3465A4">   --&gt;</font> src/main.rs:44
-<font color="#3465A4"><b>    |</b></font>
-<font color="#3465A4"><b> 44 |</b></font> Fun facets shalld cause some erroris.
-<font color="#3465A4"><b>    |</b></font><font color="#C4A000"><b>            ^^^^^^</b></font>
-<font color="#3465A4"><b>    |</b></font><font color="#CC0000"><b> - </b></font><font color="#4E9A06"><b>shall</b></font> or <font color="#4E9A06">shall d</font>
-<font color="#3465A4"><b>    |</b></font>
-</pre>
+<pre><code><span style="color:#CC0000"><b>error</b></span><span style="color:#D3D7CF"><b>: spellcheck</b></span>
+<span style="color:#3465A4">   --&gt;</span> src/main.rs:44
+<span style="color:#3465A4"><b>    |</b></span>
+<span style="color:#3465A4"><b> 44 |</b></span> Fun facets shalld cause some erroris.
+<span style="color:#3465A4"><b>    |</b></span><span style="color:#C4A000"><b>            ^^^^^^</b></span>
+<span style="color:#3465A4"><b>    |</b></span><span style="color:#CC0000"><b> - </b></span><span style="color:#4E9A06"><b>shall</b></span> or <span style="color:#4E9A06">shall d</span>
+<span style="color:#3465A4"><b>    |</b></span></code></pre>
 
 ### Apply Suggestions Interactively
 
@@ -38,23 +37,22 @@ cargo spellcheck check
 cargo spellcheck fix
 ```
 
-<pre><font color="#CC0000"><b>error</b></font><font color="#D3D7CF"><b>: spellcheck(Hunspell)</b></font>
-<font color="#3465A4">    --&gt;</font> /media/supersonic1t/projects/cargo-spellcheck/src/literalset.rs:291
-<font color="#3465A4"><b>     |</b></font>
-<font color="#3465A4"><b> 291 |</b></font>  Returns literl within the Err variant if not adjacent
-<font color="#3465A4"><b>     |</b></font><font color="#C4A000"><b>          ^^^^^^</b></font>
+<pre><code><span style="color:#CC0000"><b>error</b></span><span style="color:#D3D7CF"><b>: spellcheck(Hunspell)</b></span>
+<span style="color:#3465A4">    --&gt;</span> /media/supersonic1t/projects/cargo-spellcheck/src/literalset.rs:291
+<span style="color:#3465A4"><b>     |</b></span>
+<span style="color:#3465A4"><b> 291 |</b></span>  Returns literl within the Err variant if not adjacent
+<span style="color:#3465A4"><b>     |</b></span><span style="color:#C4A000"><b>          ^^^^^^</b></span>
 
-<font color="#729FCF"><b>(13/14) Apply this suggestion [y,n,q,a,d,j,e,?]?</b></font>
+<span style="color:#729FCF"><b>(13/14) Apply this suggestion [y,n,q,a,d,j,e,?]?</b></span>
 
-   <span style="background-color:#2E3436"><font color="#729FCF">lite</font></span>
-   <span style="background-color:#2E3436"><font color="#729FCF">litter</font></span>
-   <span style="background-color:#2E3436"><font color="#729FCF">litterer</font></span>
-   <span style="background-color:#2E3436"><font color="#729FCF">liter l</font></span>
-   <span style="background-color:#2E3436"><font color="#729FCF">liters</font></span>
-   <span style="background-color:#2E3436"><font color="#729FCF">literal</font></span>
-   <span style="background-color:#2E3436"><font color="#729FCF">liter</font></span>
- <font color="#8AE234"><b>»</b></font> <span style="background-color:#2E3436"><font color="#FCE94F">a custom replacement literal</font></span>
-</pre>
+   <span style="background-color:#2E3436;color:#729FCF;">lite</span>
+   <span style="background-color:#2E3436;color:#729FCF;">litter</span>
+   <span style="background-color:#2E3436;color:#729FCF;">litterer</span>
+   <span style="background-color:#2E3436;color:#729FCF;">liter l</span>
+   <span style="background-color:#2E3436;color:#729FCF;">liters</span>
+   <span style="background-color:#2E3436;color:#729FCF;">literal</span>
+   <span style="background-color:#2E3436;color:#729FCF;">liter</span>
+ <span style="color:#8AE234"><b>»</b></span> <span style="background-color:#2E3436;color:#FCE94F">a custom replacement literal</span></code></pre>
 
 ## Installation
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -3,7 +3,7 @@
 A plethora of spelling mistackz inclusive.
 
 <pre>
-<font color="#8AE234"><b>ᐲ🠒🍉 see #104</b></font>
+<span style="color:#8AE234"><b>ᐲ🠒🍉 see #104</b></span>
 </pre>
 
 'Verify #88'


### PR DESCRIPTION
You can check the result [here](https://github.com/GuillaumeGomez/cargo-spellcheck/tree/fix-markdown-html) (to be noted: github discard inline style).

It will very likely fix crates.io display by adding a `<code>` inside the `<pre>`:

![Screenshot from 2022-03-30 14-47-41](https://user-images.githubusercontent.com/3050060/160837870-267ad800-71f2-48dd-aa15-fb7f698d0b91.png)

