### PR TITLE
cache expanded, serialized artifacts and load them from their cached storage format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +204,7 @@ name = "cargo-spellcheck"
 version = "0.11.2"
 dependencies = [
  "assert_matches",
+ "bincode",
  "cargo_toml",
  "clap 3.1.6",
  "clap-verbosity-flag",
@@ -209,6 +219,7 @@ dependencies = [
  "fs-err",
  "futures",
  "glob",
+ "hex",
  "hunspell-rs",
  "indexmap",
  "iso_country",
@@ -229,6 +240,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_plain",
+ "sha2",
  "signal-hook",
  "syn",
  "thiserror",
@@ -413,6 +425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d48d8f76bd9331f19fe2aaf3821a9f9fb32c3963e1e3d6ce82a8c09cef7444a"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,15 +489,15 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.22.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
+checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
- "mio 0.7.14",
- "parking_lot 0.11.2",
+ "mio",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -492,6 +513,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,7 +530,7 @@ checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
- "parking_lot 0.12.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -511,6 +542,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -802,6 +843,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +938,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1021,15 +1078,6 @@ dependencies = [
  "hashbrown 0.11.2",
  "rayon",
  "serde",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1205,19 +1253,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow 0.3.7",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
@@ -1250,12 +1285,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if 1.0.0",
  "libc",
  "memoffset",
@@ -1394,37 +1428,12 @@ checksum = "5e72e30578e0d0993c8ae20823dd9cff2bc5517d2f586a8aef462a581e8a03eb"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1569,21 +1578,21 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_la-arena"
-version = "0.0.102"
+version = "0.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0df673783137ac10a561b40c3c724503e4aeefa6e4261df268d2f1b9adc172"
+checksum = "5d3c28b7ef8ec05b8472d93d71dabc2263f8ec19a99a0c0469be7a11ab399d2a"
 
 [[package]]
 name = "ra_ap_limit"
-version = "0.0.102"
+version = "0.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6388e66ec2a29941f451e40a17fd27abb12a2d4aac8b9e16d4eb44c294af73"
+checksum = "285e82c5aef76b0e5224b78799e3571a0e290cd9cd6ca32191f6e556b87b50bb"
 
 [[package]]
 name = "ra_ap_parser"
-version = "0.0.102"
+version = "0.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2bef6d2dd2f9b201730c267d351cc886023a96432977f34167d2af22ce0f548"
+checksum = "626b67c1acb6795674bd4d83f0700245fb67ad7bb21d0de815578b227fb33767"
 dependencies = [
  "drop_bomb",
  "ra_ap_limit",
@@ -1592,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_profile"
-version = "0.0.102"
+version = "0.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61c3aac011216b345f80754a91f776a72d267d4e8a42c721c62a5959eb4feec"
+checksum = "15128f7955c99c82ba17db6d3c3c921719bcb9a6912054486949149d02c4e79a"
 dependencies = [
  "cfg-if 1.0.0",
  "countme",
@@ -1607,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_stdx"
-version = "0.0.102"
+version = "0.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9b01b789b9b41433aa76f10e842edd02640aff4fffc1719dd467b39f3fe10c"
+checksum = "76bf670033bf7b7a707f4e2957108af2b545475808855b3023a1fac69403371d"
 dependencies = [
  "always-assert",
  "libc",
@@ -1619,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_syntax"
-version = "0.0.102"
+version = "0.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88f11a5ee695d7910fbbf87e237ed778b70d0352ce4d23bd0cabe8e3341c797"
+checksum = "6de766172d46071afc07041d37526d4ee4c6446e51d6f5f76b7d0eca816ad21a"
 dependencies = [
  "cov-mark",
  "indexmap",
@@ -1639,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_text_edit"
-version = "0.0.102"
+version = "0.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c5d159fa498994a62dc7393182251a235815ad6f83cb2efab1563d15446634"
+checksum = "5037f6423837aff4117ac62a3bf8fae0fd876e804e3101e201030fb80dae7846"
 dependencies = [
  "itertools 0.10.3",
  "text-size",
@@ -1957,6 +1966,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,12 +2003,12 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio 0.7.14",
+ "mio",
  "signal-hook",
 ]
 
@@ -2183,10 +2203,10 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.2",
+ "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2294,6 +2314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "signal-hook",
  "syn",
  "thiserror",
+ "thousands",
  "tokio",
  "toml",
  "url",
@@ -2159,6 +2160,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,8 +110,13 @@ all = ["hunspell", "nlprules"]
 [profile.dev]
 build-override = { opt-level = 2 }
 
-[profile.dev.package.backtrace]
-opt-level = 3
+[profile.dev.package]
+backtrace = { opt-level = 3 }
+bincode = { opt-level = 3 }
+xz2 = { opt-level = 3 }
+sha2 = { opt-level = 3 }
+hunspell-rs = { opt-level = 3 }
+nlprule = { opt-level = 3 }
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ xz2 = "0.1"
 sha2 = "0.10"
 bincode = "1"
 hex = "0.4"
+thousands = "0.2"
 
 [dev-dependencies]
 # for stripping ansi color codes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ xz2 = "0.1"
 color-eyre = "0.6"
 cargo_toml = "^0.11.4"
 console = "0.15"
-crossterm = "0.22.1"
+crossterm = "0.23.2"
 # for the config file
 directories = "4.0.1"
 
@@ -52,7 +52,7 @@ log = "0.4"
 num_cpus = "1.13"
 proc-macro2 = { version = "1", features = ["span-locations"] }
 pulldown-cmark = "0.9.1"
-ra_ap_syntax = "0.0.102"
+ra_ap_syntax = "0.0.104"
 rayon = "1.5"
 regex = "1.5"
 serde = { version = "1", features = ["derive"] }
@@ -67,7 +67,7 @@ walkdir = "2"
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 futures = "0.3"
 
-uuid = { version = "0.8.2", features = ["v4"] }
+uuid = { version = "1.0.0", features = ["v4"] }
 
 # config parsing, must be independent of features
 
@@ -84,13 +84,19 @@ fd-lock = { version = "3", optional = true }
 # full grammar check, but also tokenization and disambiguation
 nlprule = { version = "=0.6.4", optional = true }
 
+# cache some expensive expansions
+xz2 = "0.1"
+sha2 = "0.10"
+bincode = "1"
+hex = "0.4"
+
 [dev-dependencies]
 # for stripping ansi color codes
 console = "0.15"
 assert_matches = "1"
 maplit = "1"
 serde_plain = "1"
-nix = "0.23"
+nix = "0.24.1"
 
 [features]
 default = ["hunspell", "nlprules"]

--- a/src/checker/cached.rs
+++ b/src/checker/cached.rs
@@ -1,0 +1,162 @@
+use crate::errors::*;
+
+use hex::ToHex;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+use sha2::Digest;
+use std::io::Seek;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct CacheEntry<T> {
+    what: PathBuf,
+    val: T,
+}
+
+pub struct CachedValue<T> {
+    /// Time it took to..
+    /// load the value from disk if it was there.
+    pub fetch: Option<Duration>,
+    /// Updating the disk cache
+    pub update: Option<Duration>,
+    /// Create a new one if needed
+    pub creation: Option<Duration>,
+    /// The accumulated duration,
+    pub total: Duration,
+    /// The actual value.
+    pub value: T,
+}
+
+pub struct Cached<T> {
+    cache_file: fd_lock::RwLock<fs_err::File>,
+    // What to cache.
+    what: PathBuf,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<'a, T> Cached<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    ///
+    pub fn new(what: impl AsRef<Path>, cache_dir: impl AsRef<Path>) -> Result<Self> {
+        let what = what.as_ref();
+        let what_digest = sha2::Sha256::digest(what.to_string_lossy().as_bytes());
+        let cache_dir = cache_dir.as_ref();
+        let cache_file = cache_dir.join(what_digest.as_slice().encode_hex::<String>());
+        let cache_file = fs_err::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(cache_file)?;
+        Ok(Self {
+            cache_file: fd_lock::RwLock::new(cache_file),
+            what: what.to_path_buf(),
+            _phantom: std::marker::PhantomData,
+        })
+    }
+
+    pub fn fetch_or_update(
+        &mut self,
+        create: impl FnOnce(&Path) -> Result<T>,
+    ) -> Result<CachedValue<T>> {
+        let total_start = Instant::now();
+        match self.fetch() {
+            Ok(Some(value)) => {
+                let elapsed = total_start.elapsed();
+                Ok(CachedValue {
+                    value,
+                    fetch: Some(elapsed.clone()),
+                    update: None,
+                    creation: None,
+                    total: elapsed,
+                })
+            }
+            Ok(None) => {
+                let fetch = Some(total_start.elapsed());
+
+                let creation_start = Instant::now();
+                let value = create(&self.what)?;
+                let creation = Some(creation_start.elapsed());
+
+                let update_start = Instant::now();
+                if let Err(err) = self.update(&value) {
+                    log::warn!("Failed to write value to cached: {:?}", err);
+                }
+                let update = Some(update_start.elapsed());
+                let total = total_start.elapsed();
+                Ok(CachedValue {
+                    value,
+                    fetch,
+                    update,
+                    creation,
+                    total,
+                })
+            }
+            Err(err) => {
+                log::warn!("Overriding existing value that failed to load: {:?}", err);
+
+                let fetch = Some(total_start.elapsed());
+
+                let creation_start = Instant::now();
+                let value = create(&self.what)?;
+                let creation = Some(creation_start.elapsed());
+
+                let update_start = Instant::now();
+                if let Err(err) = self.update(&value) {
+                    log::warn!("Failed to update cached: {:?}", err);
+                }
+                let update = Some(update_start.elapsed());
+                let total = total_start.elapsed();
+                Ok(CachedValue {
+                    value,
+                    fetch,
+                    update,
+                    creation,
+                    total,
+                })
+            }
+        }
+    }
+
+    pub fn fetch(&mut self) -> Result<Option<T>> {
+        let guard = self.cache_file.read()?;
+        let buf = std::io::BufReader::new(guard.file());
+        let decompressed = xz2::bufread::XzDecoder::new(buf);
+        match bincode::deserialize_from(decompressed) {
+            Ok(CacheEntry { what, val }) => {
+                if &what == &self.what {
+                    log::warn!("Cached value does not match what identifier, removing");
+                    Ok(None)
+                } else {
+                    log::debug!("Cache hit");
+                    Ok(Some(val))
+                }
+            }
+            Err(e) => {
+                log::warn!("Failed to load cached value: {:?}", e);
+                Ok(None)
+            }
+        }
+    }
+
+    pub fn update(&mut self, val: &T) -> Result<()> {
+        let mut write_guard = self.cache_file.write()?;
+
+        let entry = CacheEntry {
+            what: self.what.clone(),
+            val,
+        };
+        let encoded: Vec<u8> = bincode::serialize(&entry).unwrap();
+        let mut encoded = &encoded[..];
+        let mut compressed = xz2::bufread::XzEncoder::new(&mut encoded, 6);
+
+        // effectively truncate, but without losing the lock
+        let file = write_guard.file_mut();
+        file.rewind()?;
+        std::io::copy(&mut compressed, file)?;
+        let loco = file.stream_position()?;
+        file.set_len(loco)?;
+        Ok(())
+    }
+}

--- a/src/checker/cached.rs
+++ b/src/checker/cached.rs
@@ -123,14 +123,18 @@ where
     pub fn fetch(&mut self) -> Result<Option<T>> {
         let guard = self.cache_file.read()?;
         let buf = std::io::BufReader::new(guard.file());
-        // let decompressed = xz2::bufread::XzDecoder::new(buf);
+        // let buf = xz2::bufread::XzDecoder::new(buf);
         match bincode::deserialize_from(buf) {
             Ok(CacheEntry { what, val }) => {
                 if &what == &self.what {
                     log::debug!("Cached value with matching what \"{}\"", &what);
                     Ok(Some(val))
                 } else {
-                    log::warn!("Cached value what \"{}\" does not match expect what \"{}\", removing", &what, &self.what);
+                    log::warn!(
+                        "Cached value what \"{}\" does not match expect what \"{}\", removing",
+                        &what,
+                        &self.what
+                    );
                     Ok(None)
                 }
             }

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -9,6 +9,9 @@ use crate::errors::*;
 
 use log::debug;
 
+mod cached;
+use self::cached::Cached;
+
 mod tokenize;
 pub(crate) use self::hunspell::HunspellChecker;
 pub(crate) use self::nlprules::NlpRulesChecker;

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -46,7 +46,7 @@ pub trait Checker {
 /// Only configured checkers are used.
 pub struct Checkers {
     hunspell: Option<HunspellChecker>,
-    nlprule: Option<NlpRulesChecker>,
+    nlprules: Option<NlpRulesChecker>,
 }
 
 impl Checkers {
@@ -79,13 +79,13 @@ impl Checkers {
             &config,
             config.hunspell.as_ref()
         );
-        let nlprule = create_checker!(
+        let nlprules = create_checker!(
             "nlprules",
             NlpRulesChecker,
             &config,
             config.nlprules.as_ref()
         );
-        Ok(Self { hunspell, nlprule })
+        Ok(Self { hunspell, nlprules })
     }
 }
 
@@ -108,7 +108,7 @@ impl Checker for Checkers {
         if let Some(ref hunspell) = self.hunspell {
             collective.extend(hunspell.check(origin, chunks)?);
         }
-        if let Some(ref nlprule) = self.nlprule {
+        if let Some(ref nlprule) = self.nlprules {
             collective.extend(nlprule.check(origin, chunks)?);
         }
 

--- a/src/checker/tokenize.rs
+++ b/src/checker/tokenize.rs
@@ -22,7 +22,10 @@ lazy_static! {
 }
 
 fn maybe_display_micros(maybe_duration: impl Into<Option<std::time::Duration>>) -> String {
-    maybe_duration.into().map(|d| d.as_micros().to_string()).unwrap_or_else(|| "-".to_owned())
+    maybe_duration
+        .into()
+        .map(|d| d.as_micros().to_string())
+        .unwrap_or_else(|| "-".to_owned())
 }
 
 pub fn project_dir() -> Result<directories::ProjectDirs> {
@@ -49,7 +52,9 @@ fn tokenizer_inner<P: AsRef<Path>>(
             Ok(Tokenizer::from_reader(f)?)
         })
     } else {
-        let loader = |_: &str| -> Result<Tokenizer> { Ok(Tokenizer::from_reader(&mut &*DEFAULT_TOKENIZER_BYTES)?) };
+        let loader = |_: &str| -> Result<Tokenizer> {
+            Ok(Tokenizer::from_reader(&mut &*DEFAULT_TOKENIZER_BYTES)?)
+        };
         if true {
             let mut cached = Cached::new("::builtin::$tokenizer", cache_dir)?;
             cached.fetch_or_update(loader)

--- a/src/checker/tokenize.rs
+++ b/src/checker/tokenize.rs
@@ -10,6 +10,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
+use thousands::Separable;
 
 static DEFAULT_TOKENIZER_BYTES: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/en_tokenizer.bin"));
@@ -24,7 +25,7 @@ lazy_static! {
 fn maybe_display_micros(maybe_duration: impl Into<Option<std::time::Duration>>) -> String {
     maybe_duration
         .into()
-        .map(|d| d.as_micros().to_string())
+        .map(|d| d.as_micros().separate_with_underscores())
         .unwrap_or_else(|| "-".to_owned())
 }
 
@@ -72,7 +73,7 @@ fn tokenizer_inner<P: AsRef<Path>>(
         }
     }?;
     info!("🧮 Loaded tokenizer in {total} us (fetch: {fetch} us, update: {update} us, creation: {creation} us)",
-        total = total.as_micros(),
+        total = maybe_display_micros(total),
         fetch = maybe_display_micros(fetch),
         update = maybe_display_micros(update),
         creation = maybe_display_micros(creation),
@@ -122,7 +123,7 @@ fn rules_inner<P: AsRef<Path>>(override_path: Option<P>, cache_dir: &Path) -> Re
         cached.fetch_or_update(|_| Ok(Rules::from_reader(&mut &*DEFAULT_RULES_BYTES)?))
     }?;
     info!("🧮 Loaded rules in {total} us (fetch: {fetch} us, update: {update} us, creation: {creation} us)",
-        total = total.as_micros(),
+        total = maybe_display_micros(total),
         fetch = maybe_display_micros(fetch),
         update = maybe_display_micros(update),
         creation = maybe_display_micros(creation),

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -245,11 +245,12 @@ pub fn generate_completions<G: clap_complete::Generator, W: std::io::Write>(
 
 impl Args {
     pub fn common(&self) -> Option<&Common> {
-        match self.command {
-            Some(Sub::Check { ref common, .. })
-            | Some(Sub::Fix { ref common, .. })
-            | Some(Sub::Reflow { ref common, .. }) => Some(common),
-            _ => None,
+        match &self.command {
+            Some(Sub::Check { common, .. })
+            | Some(Sub::Fix { common, .. })
+            | Some(Sub::Reflow { common, .. }) => Some(common),
+            None => Some(&self.common),
+            Some(Sub::Completions { .. } | Sub::ListFiles { .. } | Sub::Config { .. }) => None,
         }
     }
 
@@ -464,7 +465,7 @@ impl Args {
         }
 
         debug!("Using configuration default, builtin configuration (5)");
-        Ok((Default::default(), None))
+        Ok((Config::default(), None))
     }
 
     fn load_config(&self) -> Result<(Config, Option<PathBuf>)> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -33,6 +33,7 @@ use crate::Detector;
 use fancy_regex::Regex;
 
 use fs_err as fs;
+use log::warn;
 use serde::{Deserialize, Serialize};
 use std::convert::AsRef;
 use std::fmt;
@@ -236,6 +237,7 @@ fn default_nlprules() -> Option<NlpRulesConfig> {
     if cfg!(feature = "nlprules") {
         Some(NlpRulesConfig::default())
     } else {
+        warn!("Cannot enable nlprules, since it wasn't compiled with `nlprules` as checker");
         None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,9 +138,7 @@ impl Drop for TinHat {
 }
 
 /// The inner main.
-pub fn run() -> Result<ExitCode> {
-    let args = Args::parse(std::env::args()).unwrap_or_else(|e| e.exit());
-
+pub fn run(args: Args) -> Result<ExitCode> {
     let _ = ::rayon::ThreadPoolBuilder::new()
         .num_threads(args.job_count())
         .build_global();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 use log::warn;
 
-use cargo_spellcheck::{action, errors::Result, run};
+use cargo_spellcheck::{action, errors::Result, run, Args};
 
 #[allow(missing_docs)]
 fn main() -> Result<()> {
     let _ = color_eyre::install()?;
-    let res = run();
+    let args = Args::parse(std::env::args()).unwrap_or_else(|e| e.exit());
+    let res = run(args);
     // no matter what, restore the terminal
     if let Err(e) = action::interactive::ScopedRaw::restore_terminal() {
         warn!("Failed to restore terminal: {}", e);


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

Adds a caching layer to `nlprules::{Rules,Tokenizer}`, actually regresses tokenizer loading speed by 300us, have yet to check for `Tokenizer`.

<!---
Delete all that do not apply:
-->

 * 🩹 Bug Fix

## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [x] Documentation is thorough
