### PR TITLE
fix: remove suggestions' duplication

### DIFF
--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -114,6 +114,24 @@ impl Checker for Checkers {
 
         let mut suggestions: Vec<Suggestion<'s>> = Vec::from_iter(collective);
         suggestions.sort();
+        if suggestions.len() == 0 {
+            return Ok(suggestions);
+        }
+
+        // Iterate through suggestions and identify overlapping ones.
+        let mut omitted: Vec<CheckableChunk> = Vec::<CheckableChunk>::new();
+        let mut i: usize = 0;
+        while i < suggestions.len() - 1 as usize {
+            let cur = suggestions[i].clone();
+            i += 1;
+
+            while cur.is_overlapped(&suggestions[i]) {
+                let omit = suggestions.remove(i);
+                omitted.push(omit.chunk.clone());
+            }
+        }
+
+        // Re-run the checker and merge the results
 
         Ok(suggestions)
     }

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -119,17 +119,15 @@ impl Checker for Checkers {
         }
 
         // Iterate through suggestions and identify overlapping ones.
-        let _omitted = suggestions
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, cur)| {
-                if idx > 0 && cur.is_overlapped(&suggestions[idx - 1]) {
-                    Some(cur.chunk.clone())
+        let suggestions = Vec::from_iter(suggestions.clone().into_iter().enumerate().filter_map(
+            |(idx, cur)| {
+                if idx == 0 || !cur.is_overlapped(&suggestions[idx - 1]) {
+                    Some(cur)
                 } else {
                     None
                 }
-            })
-            .collect::<Vec<_>>();
+            },
+        ));
 
         Ok(suggestions)
     }

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -104,7 +104,7 @@ impl Checker for Checkers {
     where
         'a: 's,
     {
-        let mut collective = Vec::<Suggestion<'s>>::with_capacity(chunks.len());
+        let mut collective = HashSet::<Suggestion<'s>>::new();
         if let Some(ref hunspell) = self.hunspell {
             collective.extend(hunspell.check(origin, chunks)?);
         }
@@ -112,9 +112,7 @@ impl Checker for Checkers {
             collective.extend(nlprule.check(origin, chunks)?);
         }
 
-        // Convert into a set to remove the duplicated suggestions
-        let set: HashSet<Suggestion> = HashSet::from_iter(collective.iter().cloned());
-        let mut suggestions: Vec<Suggestion<'s>> = Vec::from_iter(set);
+        let mut suggestions: Vec<Suggestion<'s>> = Vec::from_iter(collective);
         suggestions.sort();
 
         Ok(suggestions)

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -10,6 +10,8 @@ use crate::errors::*;
 mod cached;
 use self::cached::Cached;
 
+use std::collections::HashSet;
+
 mod tokenize;
 pub(crate) use self::hunspell::HunspellChecker;
 pub(crate) use self::nlprules::NlpRulesChecker;
@@ -110,9 +112,12 @@ impl Checker for Checkers {
             collective.extend(nlprule.check(origin, chunks)?);
         }
 
-        collective.sort();
+        // Convert into a set to remove the duplicated suggestions
+        let set: HashSet<Suggestion> = HashSet::from_iter(collective.iter().cloned());
+        let mut suggestions: Vec<Suggestion<'s>> = Vec::from_iter(set);
+        suggestions.sort();
 
-        Ok(collective)
+        Ok(suggestions)
     }
 }
 

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -119,19 +119,17 @@ impl Checker for Checkers {
         }
 
         // Iterate through suggestions and identify overlapping ones.
-        let mut omitted: Vec<CheckableChunk> = Vec::<CheckableChunk>::new();
-        let mut i: usize = 0;
-        while i < suggestions.len() - 1 as usize {
-            let cur = suggestions[i].clone();
-            i += 1;
-
-            while cur.is_overlapped(&suggestions[i]) {
-                let omit = suggestions.remove(i);
-                omitted.push(omit.chunk.clone());
-            }
-        }
-
-        // Re-run the checker and merge the results
+        let _omitted = suggestions
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, cur)| {
+                if idx > 0 && cur.is_overlapped(&suggestions[idx - 1]) {
+                    Some(cur.chunk.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
 
         Ok(suggestions)
     }

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -728,15 +728,15 @@ mod tests {
         let chunk = CheckableChunk::from_str(
             CONTENT,
             indexmap::indexmap! { 0..18 => Span {
-                    start: LineColumn {
-                        line: 1,
-                        column: 0,
-                    },
-                    end: LineColumn {
-                        line: 1,
-                        column: 17,
-                    }
+                start: LineColumn {
+                    line: 1,
+                    column: 0,
+                },
+                end: LineColumn {
+                    line: 1,
+                    column: 17,
                 }
+            }
             },
             CommentVariant::TripleSlash,
         );
@@ -779,15 +779,15 @@ mod tests {
         let chunk = CheckableChunk::from_str(
             CONTENT,
             indexmap::indexmap! { 0..18 => Span {
-                    start: LineColumn {
-                        line: 1,
-                        column: 0,
-                    },
-                    end: LineColumn {
-                        line: 1,
-                        column: 17,
-                    }
+                start: LineColumn {
+                    line: 1,
+                    column: 0,
+                },
+                end: LineColumn {
+                    line: 1,
+                    column: 17,
                 }
+            }
             },
             CommentVariant::TripleSlash,
         );

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -321,7 +321,9 @@ impl<'s> Suggestion<'s> {
         if self.origin != other.origin {
             return false;
         }
-        if self.span.start.line != other.span.start.line {
+
+        if self.span.end.line < other.span.start.line || other.span.end.line < self.span.start.line
+        {
             return false;
         }
 

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -327,7 +327,10 @@ impl<'s> Suggestion<'s> {
             return false;
         }
 
-        if self < other {
+        if self.span.start.line < other.span.start.line
+            || (self.span.start.line == other.span.start.line
+                && self.span.start.column < other.span.start.column)
+        {
             self.span.end.column > other.span.start.column
         } else {
             self.span.start.column < other.span.end.column


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

 * 🩹 Bug Fix

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Closes #10 .

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
To remove the duplicated suggestions, the `Vector of Suggestion` is converted once to a `HashSet` and then again to a `Vector`.

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particular impl details
are wanted, state them here too.
-->
This PR tries to resolve the 🔰 part of the issue, but I'm willing to work on further parts of it.

## 📜 Checklist

 * [x] Works on the `./demo` sub directory
 * [ ] Test coverage is excellent and passes
 * [x] Documentation is thorough
