### PR TITLE
Documentation: cargo-binstall and GitHub Actions

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -31,12 +31,18 @@ Specify your arguments as needed.
 Install `cargo-spellcheck` via [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) and then use it like you would locally.
 Alternatively you can use `cargo install cargo-spellcheck` to compile it from source.
 
+```bash
+cargo binstall --no-confirm cargo-spellcheck
+
+cargo-spellcheck --code 1
+```
+
 ## Git hooks
 
 If you want to manually configure `cargo-spellcheck` to run on git commits:
 
-```sh
-#!/usr/bin/sh
+```bash
+#!/usr/bin/env bash
 
 # Redirect output to stderr.
 exec 1>&2

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -2,8 +2,34 @@
 
 ## CI/CD
 
-`cargo-spellcheck` can be configured with `-m <code>` to return a non-zero
+`cargo-spellcheck` can be configured with `--code <code>` to return a non-zero
 return code if mistakes are found instead of `0`.
+
+### GitHub Actions
+
+[Create a workflow](https://docs.github.com/en/actions/quickstart) for your project and add the following example as steps.
+
+The first step installs cargo-spellcheck on the runner.
+The second step loads your source code into the runner environment.
+The third step runs a command in a shell like you would normally do with cargo spellcheck.
+Specify your arguments as needed.
+
+```yaml
+- name: Install cargo-spellcheck
+  uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-spellcheck
+    
+- uses: actions/checkout@v3
+
+- name: Run cargo-spellcheck
+  run: cargo spellcheck --code 1
+```
+
+### Other
+
+Install `cargo-spellcheck` via [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) and then use it like you would locally.
+Alternatively you can use `cargo install cargo-spellcheck` to compile it from source.
 
 ## Git hooks
 
@@ -15,7 +41,7 @@ If you want to manually configure `cargo-spellcheck` to run on git commits:
 # Redirect output to stderr.
 exec 1>&2
 
-exec cargo spellcheck -m 99 $(git diff-index --cached --name-only --diff-filter=AM HEAD)
+exec cargo spellcheck --code 99 $(git diff-index --cached --name-only --diff-filter=AM HEAD)
 ```
 
 Alternatively you can use [`pre-commit`](https://pre-commit.com/) to manage your git commit hooks


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

 * 📙 Documentation

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
See #297

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

Describe usage of cargo-binstall and a GitHub Action which uses cargo-binstall.

I also had some minor changes to the documentation there:

Switch `-m` to `--code` as long options especially in documentation and scripts are easier to read and understand (at least for me).

Switch from `/usr/bin/sh` to `/usr/bin/env bash`. `sh` is most often a symlink to the default shell which easily breaks on systems where the default shell isn't POSIX compliant (like `fish` or `nushell`) or the writer of the script expects bash features.

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particular impl details
are wanted, state them here too.
-->

Until a new release with updated release artefact names is released or the current `latest` is updated with different release artefact names `cargo-binstall` will just fall back to `cargo install`.

## 📜 Checklist

 * [ ] Works on the `./demo` sub directory
 * [ ] Test coverage is excellent and passes
 * [ ] Documentation is thorough
