### PR TITLE
Implement Optional Footnote References Ignore

### DIFF
--- a/doc-chunks/src/chunk.rs
+++ b/doc-chunks/src/chunk.rs
@@ -9,11 +9,11 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::path::Path;
 
-use crate::PlainOverlay;
 use crate::{
     util::{sub_char_range, sub_chars},
     Range, Span,
 };
+use crate::{Ignores, PlainOverlay};
 
 /// Definition of the source of a checkable chunk
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -364,8 +364,8 @@ impl CheckableChunk {
 
     /// Obtain an accessor object containing mapping and string representation,
     /// removing the markdown annotations.
-    pub fn erase_cmark(&self) -> PlainOverlay {
-        PlainOverlay::erase_cmark(self)
+    pub fn erase_cmark(&self, ignores: &Ignores) -> PlainOverlay {
+        PlainOverlay::erase_cmark(self, ignores)
     }
 
     /// Obtain the length in characters.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,14 @@ allow_concatenation = true
 # And the counterpart, which accepts words with dashes, when the suggestion has
 # recommendations without the dashes. This is less common.
 allow_dashed = false
+# Check the expressions in the footnote references. By default this is turned on
+# to remain backwards compatible but disabling it could be particularly useful
+# when one uses abbreviations instead of numbers as footnote references.  For
+# instance by default the fragment `hello[^xyz]` would be spellchecked as
+# `helloxyz` which is obviously a misspelled word, but by turning this check
+# off, it will skip validating the reference altogether and will only check the
+# word `hello`.
+check_footnote_references = false
 
 [NlpRules]
 # Allows the user to override the default included

--- a/src/checker/dummy.rs
+++ b/src/checker/dummy.rs
@@ -39,7 +39,7 @@ impl Checker for DummyChecker {
         let chunk = chunks
             .first()
             .expect("DummyChecker expects at least one chunk");
-        let plain = chunk.erase_cmark();
+        let plain = chunk.erase_cmark(&Default::default());
         let txt = plain.as_str();
         for (index, range) in apply_tokenizer(&tokenizer, txt).enumerate() {
             log::trace!("****Token[{}]: >{}<", index, sub_chars(txt, range.clone()));

--- a/src/checker/nlprules.rs
+++ b/src/checker/nlprules.rs
@@ -114,7 +114,12 @@ fn check_chunk<'a>(
     tokenizer: &Tokenizer,
     rules: &Rules,
 ) -> Vec<Suggestion<'a>> {
-    let plain = chunk.erase_cmark();
+    // TODO We should control which parts need to be ignored of the markdown
+    // entities, however the `NlpRulesConfig`, which is the only configuration
+    // we receive in the constructor does not contain the same quirks (or in
+    // fact any other similar settings) as the Hunspell one, so we cannot obtain
+    // this setting, therefore we fallback to default
+    let plain = chunk.erase_cmark(&Default::default());
     log::trace!("{plain:?}");
     let txt = plain.as_str();
 

--- a/src/config/hunspell.rs
+++ b/src/config/hunspell.rs
@@ -30,15 +30,25 @@ pub struct Quirks {
     /// Treats sequences of emojis as OK.
     #[serde(default = "yes")]
     pub allow_emojis: bool,
+    /// Check the expressions in the footnote references. By default this is
+    /// turned on to remain backwards compatible but disabling it could be
+    /// particularly useful when one uses abbreviations instead of numbers as
+    /// footnote references.  For instance by default the fragment `hello[^xyz]`
+    /// would be spellchecked as `helloxyz` which is obviously a misspelled
+    /// word, but by turning this check off, it will skip validating the
+    /// reference altogether and will only check the word `hello`.
+    #[serde(default = "yes")]
+    pub check_footnote_references: bool,
 }
 
 impl Default for Quirks {
     fn default() -> Self {
         Self {
-            transform_regex: vec![],
+            transform_regex: Vec::new(),
             allow_concatenation: false,
             allow_dashes: false,
             allow_emojis: true,
+            check_footnote_references: true,
         }
     }
 }
@@ -58,6 +68,10 @@ impl Quirks {
 
     pub(crate) fn transform_regex(&self) -> &[WrappedRegex] {
         &self.transform_regex
+    }
+
+    pub(crate) fn check_footnote_references(&self) -> bool {
+        self.check_footnote_references
     }
 }
 

--- a/src/reflow/tests.rs
+++ b/src/reflow/tests.rs
@@ -92,7 +92,7 @@ macro_rules! reflow_content {
         let chunks = docs.get(&$content_type).expect("Contains test data. qed");
         assert_eq!(dbg!(chunks).len(), 1);
         let chunk = &chunks[0];
-        let _plain = chunk.erase_cmark();
+        let _plain = chunk.erase_cmark(&Default::default());
         let suggestions = reflow(&$content_type, chunk, &CFG).expect("Reflow is working. qed");
 
         let patches = suggestions
@@ -134,7 +134,7 @@ macro_rules! reflow_content {
         let chunks = docs.get(&$content_type).expect("Contains test data. qed");
         assert_eq!(dbg!(chunks).len(), 1);
         let chunk = &chunks[0];
-        let _plain = chunk.erase_cmark();
+        let _plain = chunk.erase_cmark(&Default::default());
         let suggestions = reflow(&$content_type, chunk, &CFG).expect("Reflow is working. qed");
 
         assert_eq!(
@@ -159,7 +159,7 @@ macro_rules! reflow_content {
         let chunks = docs.get(&$content_type).expect("Contains test data. qed");
         assert_eq!(dbg!(chunks).len(), 1);
         let chunk = &chunks[0];
-        let _plain = chunk.erase_cmark();
+        let _plain = chunk.erase_cmark(&Default::default());
         println!("reflow content:\n {:?}", $content);
         let suggestions = reflow(&$content_type, chunk, &CFG).expect("Reflow is working. qed");
         let patches = suggestions


### PR DESCRIPTION
## What does this PR accomplish?

 * 🦚 Feature
 * 📙 Documentation

## Changes proposed by this PR:

This PR introduces the option in the configuration to skip checking the footnote references, i.e. under `[Hunspell.quirks]` it introduces a new option, called `check_footnote_references` which is by default set to `true` for backwards compatibility and can be explicitly opted out by setting it to `false`.

As the doc-comment explains it, this is very useful when the markdown uses abbreviations as footnote references (akin to how one would use short link references) but unlike link references this is never skipped.  Which results in the word the footnote had been applied to concatenated with the footnote reference itself, e.g.

```md
Hello[^abc].
```

Will result in checking for spelling against the segment `Helloabc`.

## 📜 Checklist

 * [X] Works on the `./demo` sub directory
 * [X] Test coverage is excellent and passes
 * [X] Documentation is thorough
