### PR TITLE
Inline format args, optimize perf

### DIFF
--- a/doc-chunks/src/chunk.rs
+++ b/doc-chunks/src/chunk.rs
@@ -136,10 +136,7 @@ impl CheckableChunk {
     /// ]
     /// ```
     pub fn find_spans(&self, range: Range) -> IndexMap<Range, Span> {
-        log::trace!(target: "find_spans",
-            "Chunk find_span {:?}",
-            &range
-        );
+        log::trace!(target: "find_spans", "Chunk find_span {range:?}");
 
         let Range { start, end } = range;
         self.source_mapping
@@ -147,7 +144,7 @@ impl CheckableChunk {
             .skip_while(|(fragment_range, _span)| fragment_range.end <= start)
             .take_while(|(fragment_range, _span)| fragment_range.start < end)
             .inspect(|x| {
-                log::trace!(target: "find_spans", ">>> item {:?} ∈ {:?}", &range, x.0);
+                log::trace!(target: "find_spans", ">>> item {:?} ∈ {:?}", range, x.0);
             })
             .filter(|(fragment_range, _)| {
                 // could possibly happen on empty documentation lines with `///`
@@ -163,11 +160,7 @@ impl CheckableChunk {
                 let (fragment_span, fragment_range, sub_fragment_range) =
                     (fragment_span, fragment_range, sub_fragment_range.clone());
                 log::trace!(target: "find_spans",
-                    ">> fragment: span: {:?} => range: {:?} | sub: {:?} -> sub_fragment: {:?}",
-                    &fragment_span,
-                    &fragment_range,
-                    range,
-                    &sub_fragment_range,
+                    ">> fragment: span: {fragment_span:?} => range: {fragment_range:?} | sub: {range:?} -> sub_fragment: {sub_fragment_range:?}",
                 );
 
                 log::trace!(target: "find_spans",
@@ -227,9 +220,7 @@ impl CheckableChunk {
                     debug_assert_eq!(sub_fragment_span_len, sub_fragment_range.len());
                 }
                 log::trace!(
-                    ">> sub_fragment range={:?} span={:?} => {}",
-                    &sub_fragment_range,
-                    &sub_fragment_span,
+                    ">> sub_fragment range={sub_fragment_range:?} span={sub_fragment_span:?} => {}",
                     self.display(sub_fragment_range.clone()),
                 );
 
@@ -494,6 +485,6 @@ impl<'a> fmt::Display for ChunkDisplay<'a> {
             oob.apply_to("!!!")
         };
 
-        write!(formatter, "{}{}{}", ctx1, highlight, ctx2)
+        write!(formatter, "{ctx1}{highlight}{ctx2}")
     }
 }

--- a/doc-chunks/src/cluster.rs
+++ b/doc-chunks/src/cluster.rs
@@ -75,13 +75,11 @@ impl Clusters {
         if let Some(cls) = self.set.last_mut() {
             if let Err(trimmed_literal) = cls.add_adjacent(trimmed_literal) {
                 log::trace!(target: "documentation",
-                    "appending, but failed to append: {:?} to set {:?}",
-                    &trimmed_literal,
-                    &cls
+                    "appending, but failed to append: {trimmed_literal:?} to set {cls:?}",
                 );
                 self.set.push(LiteralSet::from(trimmed_literal))
             } else {
-                log::trace!("successfully appended to existing: {:?} to set", &cls);
+                log::trace!("successfully appended to existing: {cls:?} to set");
             }
         } else {
             self.set.push(LiteralSet::from(trimmed_literal));
@@ -102,8 +100,7 @@ impl Clusters {
                     if let Ok(comment) = syn::parse2::<DocComment>(group.stream()) {
                         if let Err(e) = self.process_literal(source, comment) {
                             log::error!(
-                                "BUG: Failed to guarantee literal content/span integrity: {}",
-                                e
+                                "BUG: Failed to guarantee literal content/span integrity: {e}"
                             );
                             continue;
                         }

--- a/doc-chunks/src/developer.rs
+++ b/doc-chunks/src/developer.rs
@@ -65,7 +65,7 @@ impl Display for TokenType {
             TokenType::LineComment => "developer line comment",
             TokenType::Other => "not a developer comment",
         };
-        write!(f, "{}", kind)
+        write!(f, "{kind}")
     }
 }
 
@@ -221,9 +221,7 @@ fn literal_set_from_block_comment(
         ) {
             Err(s) => {
                 return Err(format!(
-                    "Failed to create literal from block comment with content \"{}\" \
-          due to error \"{}\"",
-                    next_line, s
+                    "Failed to create literal from block comment with content \"{next_line}\" due to error \"{s}\"",
                 ))
             }
             Ok(l) => l,
@@ -247,9 +245,8 @@ fn literal_set_from_block_comment(
             ) {
                 Err(s) => {
                     return Err(format!(
-                        "Failed to create literal from content \"{}\" due to error \"{}\"",
-                        next_line, s
-                    ))
+                    "Failed to create literal from content \"{next_line}\" due to error \"{s}\"",
+                ))
                 }
                 Ok(l) => l,
             };
@@ -257,8 +254,7 @@ fn literal_set_from_block_comment(
                 Ok(_) => (),
                 Err(_) => {
                     return Err(format!(
-                        "Failed to add line with content {} to literal set",
-                        next_line
+                        "Failed to add line with content {next_line} to literal set",
                     ))
                 }
             }
@@ -774,7 +770,7 @@ mod tests {
     #[test]
     fn test_single_line_comment_put_in_one_literal_set() {
         let content = " line comment";
-        let source = format!("//{}", content);
+        let source = format!("//{content}");
         let tokens = source_to_iter(&source);
         let literal_sets = construct_literal_sets(tokens);
         assert_eq!(literal_sets.len(), 1);
@@ -790,7 +786,7 @@ mod tests {
     fn test_adjacent_line_comments_put_in_same_literal_set() {
         let content_1 = " line comment 1 ";
         let content_2 = " line comment 2 ";
-        let source = format!("//{}\n//{}", content_1, content_2);
+        let source = format!("//{content_1}\n//{content_2}");
         let tokens = source_to_iter(&source);
         let literal_sets = construct_literal_sets(tokens);
         assert_eq!(literal_sets.len(), 1);
@@ -811,7 +807,7 @@ mod tests {
     fn test_non_adjacent_line_comments_put_in_different_literal_sets() {
         let content_1 = " line comment 1 ";
         let content_2 = " line comment 2 ";
-        let source = format!("//{}\nfn(){{}}\n//{}", content_1, content_2);
+        let source = format!("//{content_1}\nfn(){{}}\n//{content_2}");
         let tokens = source_to_iter(&source);
         let literal_sets = construct_literal_sets(tokens);
         assert_eq!(literal_sets.len(), 2);

--- a/doc-chunks/src/lib.rs
+++ b/doc-chunks/src/lib.rs
@@ -304,10 +304,7 @@ impl Documentation {
         }
         .unwrap_or_else(move |e| {
             log::warn!(
-                "BUG: Failed to load content from {} (dev_comments={:?}): {:?}",
-                origin,
-                dev_comments,
-                e
+                "BUG: Failed to load content from {origin} (dev_comments={dev_comments:?}): {e:?}",
             );
         });
         docs

--- a/doc-chunks/src/literal.rs
+++ b/doc-chunks/src/literal.rs
@@ -89,7 +89,7 @@ impl CommentVariant {
                     0 => "\"".to_owned(),
                     x => format!("r{}\"", "#".repeat(x.saturating_sub(1))),
                 };
-                format!(r#"{}{}"#, d, raw)
+                format!(r#"{d}{raw}"#)
             }
             CommentVariant::CommonMark => "".to_string(),
             CommentVariant::DoubleSlash => "//".to_string(),
@@ -98,10 +98,9 @@ impl CommentVariant {
             CommentVariant::SlashAsteriskEM => "/*!".to_string(),
             CommentVariant::SlashAsteriskAsterisk => "/**".to_string(),
             CommentVariant::TomlEntry => "".to_owned(),
-            unhandled => unreachable!(
-                "String representation for comment variant {:?} exists. qed",
-                unhandled
-            ),
+            unhandled => {
+                unreachable!("String representation for comment variant {unhandled:?} exists. qed")
+            }
         }
     }
     /// Return length (in bytes) of comment prefix for each variant.
@@ -342,7 +341,7 @@ fn detect_comment_variant(
                 debug_assert_eq!('"', rendered.as_bytes()[rendered.len() - 1_usize] as char);
                 (pre, post)
             } else {
-                return Err(Error::Span(format!("Regex should match >{}<", rendered)));
+                return Err(Error::Span(format!("Regex should match >{rendered}<")));
             };
 
         span.start.column += pre;
@@ -415,7 +414,7 @@ impl TrimmedLiteral {
 
         let rendered_len = rendered.chars().count();
 
-        log::trace!("extracted from source: >{}< @ {:?}", rendered, span);
+        log::trace!("extracted from source: >{rendered}< @ {span:?}");
         let (variant, span, pre, post) = detect_comment_variant(content, &rendered, span)?;
 
         let len_in_chars = rendered_len.saturating_sub(post + pre);
@@ -424,7 +423,7 @@ impl TrimmedLiteral {
             if log::log_enabled!(log::Level::Trace) {
                 let extracted =
                     sub_chars(rendered.as_str(), pre..rendered_len.saturating_sub(post));
-                log::trace!(target: "quirks", "{:?} {}||{} for \n extracted: >{}<\n rendered:  >{}<", span, pre, post, &extracted, rendered);
+                log::trace!(target: "quirks", "{span:?} {pre}||{post} for \n extracted: >{extracted}<\n rendered:  >{rendered}<");
                 assert_eq!(len_in_chars, span_len);
             }
         }
@@ -665,7 +664,7 @@ impl<'a> fmt::Display for TrimmedLiteralDisplay<'a> {
             (String::new(), oob.apply_to("!!!").to_string())
         };
 
-        write!(formatter, "{}{}{}{}{}", pre, ctx1, highlight, ctx2, post)
+        write!(formatter, "{pre}{ctx1}{highlight}{ctx2}{post}")
     }
 }
 

--- a/doc-chunks/src/markdown.rs
+++ b/doc-chunks/src/markdown.rs
@@ -105,7 +105,7 @@ impl<'a> PlainOverlay<'a> {
         let plain_range = match &cmark_range {
             SourceRange::Alias(_range, alias) => {
                 if alias.is_empty() {
-                    log::debug!("Alias for {:?} was empty. Ignoring.", s);
+                    log::debug!("Alias for {s:?} was empty. Ignoring.");
                     return;
                 }
                 // limit the lias names to 16 chars, all ascii
@@ -170,15 +170,13 @@ impl<'a> PlainOverlay<'a> {
         for (event, byte_range) in parser.into_offset_iter() {
             if byte_range.start > byte_range.end {
                 log::warn!(
-                    "Dropping event {:?} due to negative byte range {:?}, see {}",
-                    event,
-                    byte_range,
+                    "Dropping event {event:?} due to negative byte range {byte_range:?}, see {}",
                     "https://github.com/raphlinus/pulldown-cmark/issues/478"
                 );
                 continue;
             }
 
-            log::trace!("Parsing event (bytes: {:?}): {:?}", &byte_range, &event);
+            log::trace!("Parsing event (bytes: {byte_range:?}): {event:?}");
 
             let mut cursor = cmark.char_indices().enumerate().peekable();
             let mut char_cursor = 0usize;
@@ -391,7 +389,7 @@ impl<'a> PlainOverlay<'a> {
             .skip_while(|(sub, _raw)| sub.end <= start)
             .take_while(|(sub, _raw)| sub.start < end)
             .inspect(|x| {
-                log::trace!(">>> item {:?} ∈ {:?}", &condensed_range, x.0);
+                log::trace!(">>> item {:?} ∈ {:?}", condensed_range, x.0);
             })
             .filter(|(sub, _)| {
                 // could possibly happen on empty documentation lines with `///`
@@ -443,13 +441,13 @@ impl<'a> PlainOverlay<'a> {
                         None
                     }
                     .and_then(|(sub, raw)| {
-                        log::trace!("convert:  cmark-erased={:?} -> raw={:?}", sub, raw);
+                        log::trace!("convert:  cmark-erased={sub:?} -> raw={raw:?}");
 
                         if raw.is_empty() {
-                            log::warn!("linear range to spans: {:?} empty!", raw);
+                            log::warn!("linear range to spans: {raw:?} empty!");
                         } else {
                             let resolved = self.raw.find_spans(raw.clone());
-                            log::trace!("cmark-erased range to spans: {:?} -> {:?}", raw, resolved);
+                            log::trace!("cmark-erased range to spans: {raw:?} -> {resolved:?}");
                             acc.extend(resolved.into_iter());
                         }
                         Some(())
@@ -513,10 +511,10 @@ impl<'a> fmt::Debug for PlainOverlay<'a> {
             let s = sub_chars(self.plain.as_str(), plain_range.clone());
             coloured_plain.push_str(style.apply_to(s.as_str()).to_string().as_str());
         }
-        // write!(formatter, "{}", coloured_md)?;
+        // write!(formatter, "{coloured_md}")?;
 
-        writeln!(formatter, "Commonmark:\n{}", coloured_md)?;
-        writeln!(formatter, "Plain:\n{}", coloured_plain)?;
+        writeln!(formatter, "Commonmark:\n{coloured_md}")?;
+        writeln!(formatter, "Plain:\n{coloured_plain}")?;
         Ok(())
     }
 }

--- a/doc-chunks/src/span.rs
+++ b/doc-chunks/src/span.rs
@@ -49,14 +49,12 @@ impl Span {
         let me: Range = self.try_into()?;
         if scope.start > me.start {
             return Err(Error::Span(format!(
-                "start of {:?} is not inside of {:?}",
-                me, scope
+                "start of {me:?} is not inside of {scope:?}",
             )));
         }
         if scope.end < me.end {
             return Err(Error::Span(format!(
-                "end of {:?} is not inside of {:?}",
-                me, scope
+                "end of {me:?} is not inside of {scope:?}",
             )));
         }
         let offset = me.start - scope.start;
@@ -101,10 +99,7 @@ impl Span {
             // pre-filter to reduce too many calls to `extract_sub_range`
             .filter(|(fragment_range, fragment_span)| {
                 log::trace!(
-                    "extracting sub from {:?} ::: {:?} -> {:?}",
-                    self,
-                    &fragment_range,
-                    &fragment_span
+                    "extracting sub from {self:?} ::: {fragment_range:?} -> {fragment_span:?}",
                 );
                 fragment_span.start.line <= self.start.line
                     && self.end.line <= fragment_span.end.line
@@ -355,10 +350,7 @@ mod tests {
                 .zip(FRAGMENT_STR.iter()),
         ) {
             log::trace!(
-                ">>>>>>>>>>>>>>>>\ninput: {:?}\nexpected: {:?}\nfragment:>{}<",
-                input,
-                expected,
-                fragment
+                ">>>>>>>>>>>>>>>>\ninput: {input:?}\nexpected: {expected:?}\nfragment:>{fragment}<",
             );
             let range = input
                 .to_content_range(&chunk)
@@ -443,10 +435,7 @@ AlphaOmega
                 .zip(FRAGMENT_STR.iter()),
         ) {
             log::trace!(
-                ">>>>>>>>>>>>>>>>\ninput: {:?}\nexpected: {:?}\nfragment:>{}<",
-                input,
-                expected,
-                fragment
+                ">>>>>>>>>>>>>>>>\ninput: {input:?}\nexpected: {expected:?}\nfragment:>{fragment}<",
             );
 
             let range = dbg!(input)

--- a/doc-chunks/src/util.rs
+++ b/doc-chunks/src/util.rs
@@ -120,7 +120,7 @@ pub fn load_span_from<R>(mut source: R, span: Span) -> Result<String>
 where
     R: Read,
 {
-    log::trace!("Loading {:?} from source", &span);
+    log::trace!("Loading {span:?} from source");
     if span.start.line < 1 {
         return Err(Error::Span(
             "Lines are 1-indexed, can't be less than 1".to_string(),
@@ -153,7 +153,7 @@ where
         .fuse()
         .map(|(c, _byte_offset, _idx, _cursor)| c)
         .collect::<String>();
-    // log::trace!("Loading {:?} from line >{}<", &range, &line);
+    // log::trace!("Loading {range:?} from line >{line}<");
     Ok(extraction)
 }
 

--- a/src/action/interactive.rs
+++ b/src/action/interactive.rs
@@ -429,7 +429,7 @@ impl UserPicked {
                     continue;
                 }
                 sth => {
-                    log::trace!("read() something other than a key: {:?}", sth);
+                    log::trace!("read() something other than a key: {sth:?}");
                     break;
                 }
             };
@@ -453,7 +453,7 @@ impl UserPicked {
 
             drop(_guard);
             // print normally again
-            log::trace!("registered event: {:?}", &event);
+            log::trace!("registered event: {event:?}");
 
             let KeyEvent {
                 code, modifiers, ..
@@ -480,7 +480,7 @@ impl UserPicked {
                 }
                 KeyCode::Char('?') => return Ok(UserSelection::Help),
                 x => {
-                    log::trace!("Unexpected input {:?}", x);
+                    log::trace!("Unexpected input {x:?}");
                 }
             }
         }
@@ -506,7 +506,7 @@ impl UserPicked {
                 Direction::Backward => suggestions_it.next_back(),
             };
 
-            log::trace!("next() ---> {:?}", &opt_next);
+            log::trace!("next() ---> {opt_next:?}");
 
             let (idx, suggestion) = match opt_next {
                 Some(x) => x,
@@ -526,7 +526,7 @@ impl UserPicked {
                 log::trace!("BUG: Suggestion did not contain a replacement, skip");
                 continue;
             }
-            println!("{}", suggestion);
+            println!("{suggestion}");
 
             let mut state = State::from(suggestion);
 
@@ -542,7 +542,7 @@ impl UserPicked {
                         continue 'inner;
                     }
                     UserSelection::Help => {
-                        println!("{}", HELP);
+                        println!("{HELP}");
                         continue 'inner;
                     }
                     UserSelection::Replacement(bandaid) => {

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -354,12 +354,12 @@ impl Action {
         let checkers = Checkers::new(config)?;
 
         let n = documents.entry_count();
-        log::debug!("Running checkers on all documents {}", n);
+        log::debug!("Running checkers on all documents {n}");
         let mut pick_stream = stream::iter(documents.iter().enumerate())
             .map(|(mut idx, (origin, chunks))| {
                 // align the debug output with the user output
                 idx += 1;
-                log::trace!("Running checkers on {}/{},{:?}", idx, n, &origin);
+                log::trace!("Running checkers on {idx}/{n},{origin:?}");
                 let suggestions = checkers.check(origin, &chunks[..]);
                 async move { Ok::<_, color_eyre::eyre::Report>((idx, origin, suggestions?)) }
             })
@@ -378,15 +378,12 @@ impl Action {
                         UserSelection::Abort => return Ok(Finish::Abort),
                         UserSelection::Nop if !picked.is_empty() => {
                             log::debug!(
-                                "User picked patches to be applied for {}/{},{:?}",
-                                idx,
-                                n,
-                                &origin
+                                "User picked patches to be applied for {idx}/{n},{origin:?}"
                             );
                             collected_picks.extend(picked);
                         }
                         UserSelection::Nop => {
-                            log::debug!("Nothing to do for {}/{},{:?}", idx, n, &origin);
+                            log::debug!("Nothing to do for {idx}/{n},{origin:?}");
                         }
                         _ => unreachable!(
                             "All other variants are only internal to `select_interactive`. qed"
@@ -419,7 +416,7 @@ impl Action {
                         false => log::info!("❌ {} : {}", path.display(), n),
                     };
                     for suggestion in suggestions {
-                        println!("{}", suggestion);
+                        println!("{suggestion}");
                     }
                     n
                 })

--- a/src/checker/cached.rs
+++ b/src/checker/cached.rs
@@ -83,7 +83,7 @@ where
 
                 let update_start = Instant::now();
                 if let Err(err) = self.update(&value) {
-                    log::warn!("Failed to write value to cached: {:?}", err);
+                    log::warn!("Failed to write value to cached: {err:?}");
                 }
                 let update = Some(update_start.elapsed());
                 let total = total_start.elapsed();
@@ -96,7 +96,7 @@ where
                 })
             }
             Err(err) => {
-                log::warn!("Overriding existing value that failed to load: {:?}", err);
+                log::warn!("Overriding existing value that failed to load: {err:?}");
 
                 let fetch = Some(total_start.elapsed());
 
@@ -106,7 +106,7 @@ where
 
                 let update_start = Instant::now();
                 if let Err(err) = self.update(&value) {
-                    log::warn!("Failed to update cached: {:?}", err);
+                    log::warn!("Failed to update cached: {err:?}");
                 }
                 let update = Some(update_start.elapsed());
                 let total = total_start.elapsed();
@@ -127,19 +127,19 @@ where
         match bincode::deserialize_from(buf) {
             Ok(CacheEntry { what, val }) => {
                 if &what == &self.what {
-                    log::debug!("Cached value with matching what \"{}\"", &what);
+                    log::debug!("Cached value with matching what \"{what}\"");
                     Ok(Some(val))
                 } else {
                     log::warn!(
                         "Cached value what \"{}\" does not match expect what \"{}\", removing",
-                        &what,
-                        &self.what
+                        what,
+                        self.what
                     );
                     Ok(None)
                 }
             }
             Err(e) => {
-                log::warn!("Failed to load cached value: {:?}", e);
+                log::warn!("Failed to load cached value: {e:?}");
                 Ok(None)
             }
         }

--- a/src/checker/dummy.rs
+++ b/src/checker/dummy.rs
@@ -51,7 +51,7 @@ impl Checker for DummyChecker {
                     range,
                     chunk.display(range.clone())
                 );
-                let replacements = vec![format!("replacement_{}", index)];
+                let replacements = vec![format!("replacement_{index}")];
                 let suggestion = Suggestion {
                     detector,
                     span,

--- a/src/checker/hunspell.rs
+++ b/src/checker/hunspell.rs
@@ -241,10 +241,7 @@ impl HunspellCheckerInner {
             is_valid_hunspell_dic_path(extra_dic)?;
             if let Some(extra_dic) = extra_dic.to_str() {
                 if !hunspell.add_dictionary(extra_dic) {
-                    bail!(
-                        "Failed to add extra dictionary path to context {}",
-                        extra_dic
-                    )
+                    bail!("Failed to add extra dictionary path to context {extra_dic}")
                 }
             } else {
                 bail!(
@@ -303,7 +300,7 @@ impl Checker for HunspellChecker {
 
         for chunk in chunks {
             let plain = chunk.erase_cmark();
-            log::trace!("{:?}", &plain);
+            log::trace!("{plain:?}");
             let txt = plain.as_str();
             let hunspell = &*self.hunspell.0;
 
@@ -386,7 +383,7 @@ fn obtain_suggestions<'s>(
 ) {
     match hunspell.check(&word) {
         CheckResult::MissingInDictionary => {
-            log::trace!("No match for word (plain range: {:?}): >{}<", &range, &word);
+            log::trace!("No match for word (plain range: {range:?}): >{word}<");
             // get rid of single character suggestions
             let replacements = hunspell
                 .suggest(&word)
@@ -398,16 +395,16 @@ fn obtain_suggestions<'s>(
 
             // strings made of vulgar fraction or emoji
             if allow_emojis && consists_of_vulgar_fractions_or_emojis(&word) {
-                log::trace!(target: "quirks", "Found emoji or vulgar fraction character, treating {} as ok", &word);
+                log::trace!(target: "quirks", "Found emoji or vulgar fraction character, treating {word} as ok");
                 return;
             }
 
             if allow_concatenated && replacements_contain_dashless(&word, replacements.as_slice()) {
-                log::trace!(target: "quirks", "Found dashless word in replacement suggestions, treating {} as ok", &word);
+                log::trace!(target: "quirks", "Found dashless word in replacement suggestions, treating {word} as ok");
                 return;
             }
             if allow_dashed && replacements_contain_dashed(&word, replacements.as_slice()) {
-                log::trace!(target: "quirks", "Found dashed word in replacement suggestions, treating {} as ok", &word);
+                log::trace!(target: "quirks", "Found dashed word in replacement suggestions, treating {word} as ok");
                 return;
             }
             for (range, span) in plain.find_spans(range.clone()) {
@@ -423,11 +420,7 @@ fn obtain_suggestions<'s>(
             }
         }
         CheckResult::FoundInDictionary => {
-            log::trace!(
-                "Found a match for word (plain range: {:?}): >{}<",
-                &range,
-                word
-            );
+            log::trace!("Found a match for word (plain range: {range:?}): >{word}<",);
         }
     }
 }
@@ -446,10 +439,7 @@ fn is_valid_hunspell_dic(reader: impl BufRead) -> Result<()> {
     if let Some((_lineno, first)) = iter.next() {
         let first = first?;
         let _ = first.parse::<u64>().wrap_err_with(|| {
-            eyre!(
-                "First line of extra dictionary must a number, but is: >{}<",
-                first
-            )
+            eyre!("First line of extra dictionary must a number, but is: >{first}<")
         })?;
     }
     // Just check the first 10 lines, don't waste much time here
@@ -457,11 +447,7 @@ fn is_valid_hunspell_dic(reader: impl BufRead) -> Result<()> {
     for (lineno, line) in iter.take(10) {
         // All lines after must be format x.
         if let Ok(num) = line?.parse::<i64>() {
-            bail!(
-                "Line {} of extra dictionary must not be a number, but is: >{}<",
-                lineno,
-                num
-            )
+            bail!("Line {lineno} of extra dictionary must not be a number, but is: >{num}<",)
         };
     }
     Ok(())
@@ -532,7 +518,7 @@ bar
                 line.as_str()
             };
 
-            println!("testing >{}< against line #{} >{}<", word, lineno, line);
+            println!("testing >{word}< against line #{lineno} >{line}<");
             // "whitespace" is a word part of our custom dictionary
             assert_eq!(hunspell.check(word), CheckResult::FoundInDictionary);
             // Technically suggestion must contain the word itself if it is valid
@@ -540,10 +526,7 @@ bar
             // but this is not true for i.e. `clang`
             // assert!(suggestions.contains(&word.to_owned()));
             if !suggestions.contains(&word.to_owned()) {
-                eprintln!(
-                    "suggest does not contain valid self: {} ∉ {:?}",
-                    word, suggestions
-                );
+                eprintln!("suggest does not contain valid self: {word} ∉ {suggestions:?}",);
             }
         }
     }

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -68,7 +68,7 @@ impl Checkers {
                             log::debug!("Enabling {} checks.", detector);
                             Some(<$checker>::new($checker_config.unwrap())?)
                         } else {
-                            log::debug!("Checker {} is disabled by configuration.", detector);
+                            log::debug!("Checker {detector} is disabled by configuration.");
                             None
                         }
                     }
@@ -200,7 +200,7 @@ pub mod tests {
         {
             assert_eq!(
                 suggestion.replacements,
-                vec![format!("replacement_{}", index)],
+                vec![format!("replacement_{index}")],
                 "found vs expected replacement"
             );
             let extracts = load_span_from(&mut content.as_bytes(), suggestion.span).unwrap();

--- a/src/checker/nlprules.rs
+++ b/src/checker/nlprules.rs
@@ -115,7 +115,7 @@ fn check_chunk<'a>(
     rules: &Rules,
 ) -> Vec<Suggestion<'a>> {
     let plain = chunk.erase_cmark();
-    log::trace!("{:?}", &plain);
+    log::trace!("{plain:?}");
     let txt = plain.as_str();
 
     let mut acc = Vec::with_capacity(32);

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -278,7 +278,7 @@ impl Args {
             Some(Sub::ListFiles { .. }) => Action::ListFiles,
             Some(Sub::Completions { .. }) => unreachable!(),
         };
-        log::trace!("Derived action {:?} from flags/args/cmds", action);
+        log::trace!("Derived action {action:?} from flags/args/cmds");
         action
     }
 
@@ -693,27 +693,23 @@ pub fn derive_job_count(jobs: impl Into<Option<usize>>) -> usize {
         }
         Some(jobs) if jobs == 0 => {
             log::warn!(
-                "Cannot have less than one worker thread ({}). Retaining one worker thread.",
-                jobs
+                "Cannot have less than one worker thread ({jobs}). Retaining one worker thread."
             );
             1
         }
         Some(jobs) if jobs > 128 => {
-            log::warn!(
-                "Setting threads beyond 128 ({}) is insane. Capping at 128",
-                jobs
-            );
+            log::warn!("Setting threads beyond 128 ({jobs}) is insane. Capping at 128");
             128
         }
         Some(jobs) => {
-            log::info!("Explicitly set threads to {}", jobs);
+            log::info!("Explicitly set threads to {jobs}");
             jobs
         }
         None => {
             // commonly we are not the only process
             // on the machine, so use the physical cores.
             let jobs = num_cpus::get_physical();
-            log::debug!("Using the default physical thread count of {}", jobs);
+            log::debug!("Using the default physical thread count of {jobs}");
             jobs
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub fn run(args: Args) -> Result<ExitCode> {
     #[cfg(not(target_os = "windows"))]
     signal_handler(move || {
         if let Err(e) = action::interactive::ScopedRaw::restore_terminal() {
-            log::warn!("Failed to restore terminal: {}", e);
+            log::warn!("Failed to restore terminal: {e}");
         }
     });
 
@@ -146,12 +146,7 @@ pub fn run(args: Args) -> Result<ExitCode> {
             dev_comments,
             exit_code_override,
         } => {
-            log::debug!(
-                "Executing: {:?} with {:?} from {:?}",
-                action,
-                &config,
-                config_path
-            );
+            log::debug!("Executing: {action:?} with {config:?} from {config_path:?}");
 
             let documents =
                 traverse::extract(paths, recursive, skip_readme, dev_comments, &config)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ fn main() -> Result<()> {
     let res = run(args);
     // no matter what, restore the terminal
     if let Err(e) = action::interactive::ScopedRaw::restore_terminal() {
-        log::warn!("Failed to restore terminal: {}", e);
+        log::warn!("Failed to restore terminal: {e}");
     }
     let val = res?.as_u8();
     if val != 0 {

--- a/src/reflow/iter.rs
+++ b/src/reflow/iter.rs
@@ -207,7 +207,7 @@ impl<'s> Gluon<'s> {
                 char_range.end = std::cmp::max(range.end, char_range.end);
                 s
             })
-            .inspect(|x| log::trace!("Gluing together: {:?} with > <", x))
+            .inspect(|x| log::trace!("Gluing together: {x:?} with > <"))
             .join(" ");
         (self.line_counter, line_content, char_range)
     }
@@ -342,7 +342,7 @@ mod tests {
                 let expected = expected_iter
                     .next()
                     .expect("Must be of equal length at index");
-                println!("idx {} : {} <=> {}", idx, s, expected);
+                println!("idx {idx} : {s} <=> {expected}");
                 assert_eq!(s.to_owned(), expected.to_owned());
             }
         }

--- a/src/reflow/mod.rs
+++ b/src/reflow/mod.rs
@@ -154,11 +154,11 @@ fn reflow_inner<'s>(
 
         log::trace!(target: "glue", "glue[shift={}]: acc = {:?} + {:?} + {:?} + {:?} + {:?} + {:?}",
                 indentation_skip_n,
-                &pre,
-                &variant.prefix_string(),
+                pre,
+                variant.prefix_string(),
                 extra_space,
-                &content,
-                &variant.suffix_string(),
+                content,
+                variant.suffix_string(),
                 line_delimiter
         );
         acc.push_str(&pre);
@@ -220,13 +220,13 @@ impl<'s> ToString for Indentation<'s> {
 
 impl<'s> Indentation<'s> {
     pub(crate) fn new(offset: usize) -> Self {
-        log::trace!("New offset with indentation of {} ", offset);
+        log::trace!("New offset with indentation of {offset}");
         Self { offset, s: None }
     }
 
     #[allow(unused)]
     pub(crate) fn with_str(offset: usize, s: &'s str) -> Self {
-        log::trace!("New offset with indentation of {} and {:?}", offset, s);
+        log::trace!("New offset with indentation of {offset} and {s:?}");
         Self { offset, s: Some(s) }
     }
 
@@ -277,7 +277,7 @@ fn store_suggestion<'s>(
     #[cfg(debug_assertions)]
     log::trace!(
         "reflow::store_suggestion(chunk([{:?}]): {:?}",
-        &range,
+        range,
         &s[bytes_range.clone()],
     );
 
@@ -378,7 +378,7 @@ fn reflow<'s>(
     chunk: &'s CheckableChunk,
     cfg: &ReflowConfig,
 ) -> Result<Vec<Suggestion<'s>>> {
-    log::debug!("Reflowing {:?}", origin);
+    log::debug!("Reflowing {origin:?}");
     let parser = Parser::new_ext(chunk.as_str(), Options::all());
 
     let mut paragraph = 0_usize;
@@ -393,10 +393,9 @@ fn reflow<'s>(
     for (event, cover) in parser.into_offset_iter() {
         #[cfg(debug_assertions)]
         {
-            log::trace!("CMark Token: {:?}", &event);
+            log::trace!("CMark Token: {event:?}");
             log::trace!(
-                "Current segment {:?}: {:?}",
-                cover,
+                "Current segment {cover:?}: {:?}",
                 &chunk.as_str()[cover.clone()]
             );
         }

--- a/src/reflow/tests.rs
+++ b/src/reflow/tests.rs
@@ -183,15 +183,15 @@ macro_rules! reflow_content {
         let expected_n = expected.len();
         // it yields more info if we try to match as many as we can first
         for (idx, (patch, expected)) in patches.into_iter().zip(expected.into_iter()).enumerate() {
-            log::info!("Patch #{} {:?}", idx, patch);
+            log::info!("Patch #{idx} {patch:?}");
             assert_matches::assert_matches!(patch, crate::Patch::Replace {
                 replacement,
                 replace_span,
             } => {
                 let content: &'static str = $content;
                 let to_be_replaced = load_span_from(&mut content.as_bytes(), replace_span).expect("Test cases are well defined and do not cause out of bounds access. qed");
-                log::info!("Patch #{} replaces {:?} => {:?}", idx, to_be_replaced, replacement);
-                assert_eq!(replacement.as_str(), expected, "Patch #{}", idx);
+                log::info!("Patch #{idx} replaces {to_be_replaced:?} => {replacement:?}");
+                assert_eq!(replacement.as_str(), expected, "Patch #{idx}");
             })
         }
         assert_eq!(patches_n, expected_n, "Number of suggestions mismatches expected patches");
@@ -425,7 +425,7 @@ fn reflow_markdown_two_paragraphs_doc() {
 
 With a second part that is fine"#
     );
-    println!("{}", chyrped);
+    println!("{chyrped}");
 
     let expected = vec![
         r##"A long comment that spans over two"#]
@@ -572,7 +572,7 @@ fn reflow_line_delimiters() {
     ];
     for (input, expected) in TEST_DATA {
         let expected = *expected;
-        println!("{:?} should detect {:?}", input, expected);
+        println!("{input:?} should detect {expected:?}");
         assert_eq!(extract_delimiter(input), Some(expected));
     }
 }
@@ -712,7 +712,7 @@ of `0`.
 #[test]
 fn reflow_crlf() {
     const INPUT: &str = "        /// cargo spellcheck can be configured with `-m <code>` to return a non-zero return code.\r\n        struct Foo {}";
-    println!("{:?}", INPUT);
+    println!("{INPUT:?}");
     reflow_content!(40usize break ContentOrigin::TestEntityRust, INPUT
     => patches [
         "cargo spellcheck can be\r\n        /// configured with `-m <code>`\r\n        /// to return a non-zero return\r\n        /// code."

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -61,10 +61,7 @@ pub fn get_terminal_size() -> usize {
 
             static WARN_ONCE: Once = Once::new();
             WARN_ONCE.call_once(|| {
-                log::warn!(
-                    "Unable to get terminal size. Using default: {}",
-                    DEFAULT_TERMINAL_SIZE
-                );
+                log::warn!("Unable to get terminal size. Using default: {DEFAULT_TERMINAL_SIZE}");
             });
 
             DEFAULT_TERMINAL_SIZE
@@ -174,7 +171,7 @@ pub fn condition_display_content(
             .take(TAIL_DISPLAY_LEN)
             .collect::<String>();
 
-        let shortened = format!("{}...{}", head_sub, tail_sub);
+        let shortened = format!("{head_sub}...{tail_sub}");
         // FIXME if characters width a width of ineq of 1
         // ISSUE: https://github.com/drahnr/cargo-spellcheck/issues/145
         let marker_size = head_sub_range.len() + CENTER_DOTS.len() + tail_sub_range.len();
@@ -354,7 +351,7 @@ impl<'s> fmt::Display for Suggestion<'s> {
 
         error.apply_to("error").fmt(formatter)?;
         highlight
-            .apply_to(format!(": spellcheck({})", &self.detector))
+            .apply_to(format!(": spellcheck({})", self.detector))
             .fmt(formatter)?;
         formatter.write_str("\n")?;
 
@@ -433,7 +430,7 @@ impl<'s> fmt::Display for Suggestion<'s> {
             marker_size,
         );
 
-        writeln!(formatter, " {}", formatted.as_str())?;
+        writeln!(formatter, " {formatted}")?;
 
         if marker_size > 0 {
             context_marker
@@ -481,7 +478,7 @@ impl<'s> fmt::Display for Suggestion<'s> {
                     .collect::<Vec<String>>()
                     .as_slice()
                     .join(", ");
-                format!(" - {}, or {}", joined, last)
+                format!(" - {joined}, or {last}")
             }
             _n => {
                 let joined = self.replacements[..=6]
@@ -492,8 +489,8 @@ impl<'s> fmt::Display for Suggestion<'s> {
                     .join(", ");
 
                 let remaining = self.replacements.len() - 6;
-                let remaining = fix.apply_to(format!("{}", remaining)).to_string();
-                format!(" - {}, or one of {} others", joined, remaining)
+                let remaining = fix.apply_to(format!("{remaining}")).to_string();
+                format!(" - {joined}, or one of {remaining} others")
             }
         };
 
@@ -510,7 +507,7 @@ impl<'s> fmt::Display for Suggestion<'s> {
         }
 
         if let Some(ref description) = self.description {
-            writeln!(formatter, "   {}", description)?;
+            writeln!(formatter, "   {description}")?;
         }
         Ok(())
     }
@@ -522,7 +519,7 @@ impl<'s> fmt::Debug for Suggestion<'s> {
             Ok(printable) => write!(
                 formatter,
                 "({}, {:?}, {:?})",
-                &printable,
+                printable,
                 printable.1,
                 self.replacements.as_slice()
             ),
@@ -1014,8 +1011,8 @@ mod tests {
 
         let suggestion = dbg!(suggestion);
 
-        log::info!("fmt debug=\n{:?}\n<", suggestion);
-        log::info!("fmt display=\n{}\n<", suggestion);
+        log::info!("fmt debug=\n{suggestion:?}\n<");
+        log::info!("fmt display=\n{suggestion}\n<");
     }
 
     #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -32,7 +32,7 @@ fn parse_and_construct() {
     let chunk = &chunks[0];
     assert_eq!(chunk.as_str(), TEST_RAW.to_owned());
     let plain = chunk.erase_cmark();
-    println!("{:?}", &plain);
+    println!("{plain:?}");
 
     assert_eq!(TEST_PLAIN, plain.as_str());
 
@@ -332,7 +332,7 @@ struct CAPI;
             let mut it = suggestions.into_iter();
 
             let mut expected = |word: &'static str| {
-                log::info!("Working on expected token >{}<", word);
+                log::info!("Working on expected token >{word}<");
                 let suggestion = dbg!(it.next()).expect("Number of words is by test design equal to the number of expects. qed");
                 let _s = dbg!(suggestion.chunk.as_str());
 
@@ -347,10 +347,10 @@ struct CAPI;
                     suggestion.chunk.display(range.clone())
                 );
 
-                log::info!("Checking word boundaries of >{}< against the chunk/range", word);
+                log::info!("Checking word boundaries of >{word}< against the chunk/range");
                 assert_eq!(word, sub_chars(chunk.as_str(), range));
 
-                log::info!("Checking word boundaries of >{}< against the source/span", word);
+                log::info!("Checking word boundaries of >{word}< against the source/span");
                 let alternative = load_span_from($source.as_bytes(), suggestion.span.clone())
                     .expect("Span loading must succeed");
 
@@ -885,10 +885,10 @@ fn find_spans_and_coverage_integrity() -> Result<()> {
         let fs = load_span_from(SOURCE.as_bytes(), find_span.clone())?;
         let fr = sub_char_range(chunk.as_str(), find_range.clone());
         let x = load_span_from(SOURCE.as_bytes(), expected.clone())?;
-        log::trace!("[find]chunk[range]: {:?}", fr);
-        log::trace!("[find]excerpt(true): {:?}", fs);
-        log::trace!("[cove]excerpt(true): {:?}", cs);
-        log::trace!("expected: {:?}", x);
+        log::trace!("[find]chunk[range]: {fr:?}");
+        log::trace!("[find]excerpt(true): {fs:?}");
+        log::trace!("[cove]excerpt(true): {cs:?}");
+        log::trace!("expected: {x:?}");
         assert_eq!(coverage_span, expected);
         assert_eq!(find_span, expected);
         assert_eq!(fr, x);
@@ -1013,7 +1013,7 @@ fn find_line_length_docmacro() {
         .filter_level(log::LevelFilter::Trace)
         .try_init();
 
-    println!("{}", SOURCE);
+    println!("{SOURCE}");
     let set = gen_literal_set(SOURCE);
     let chunk = dbg!(CheckableChunk::from_literalset(set));
 

--- a/src/tinhat.rs
+++ b/src/tinhat.rs
@@ -47,7 +47,7 @@ where
                     fx();
                     signal_hook::low_level::exit(130);
                 }
-                sig => log::warn!("Received unhandled signal {}, ignoring", sig),
+                sig => log::warn!("Received unhandled signal {sig}, ignoring"),
             }
         }
     });

--- a/src/traverse/mod.rs
+++ b/src/traverse/mod.rs
@@ -127,15 +127,11 @@ fn extract_modules_recurse<P: AsRef<Path>>(
             },
             TokenTree::Punct(punct) => {
                 if let SeekingFor::ModulFin(ref mod_name) = state {
-                    log::trace!("✨ Found a module: {}", mod_name);
+                    log::trace!("✨ Found a module: {mod_name}");
                     if punct.as_char() == ';' && punct.spacing() == Spacing::Alone {
                         extract_modules_recurse_collect(path, &mut acc, &mod_name)?;
                     } else {
-                        log::trace!(
-                            "🍂 Either not alone or not a semi colon {:?} - incomplete mod {}",
-                            punct,
-                            mod_name
-                        );
+                        log::trace!("🍂 Either not alone or not a semi colon {punct:?} - incomplete mod {mod_name}");
                     }
                 }
                 state = SeekingFor::ModulKeyword;
@@ -158,7 +154,7 @@ pub(crate) fn extract_modules_from_file<P: AsRef<Path>>(path: P) -> Result<HashS
     if let Some(path_str) = path.to_str() {
         let s = fs::read_to_string(path_str)?;
         let stream = syn::parse_str::<proc_macro2::TokenStream>(s.as_str())
-            .wrap_err_with(|| eyre!("File {} has syntax errors", path_str))?;
+            .wrap_err_with(|| eyre!("File {path_str} has syntax errors"))?;
         let acc = extract_modules_recurse(path.to_owned(), stream)?;
         log::debug!(
             "🥞 Recursed into {} modules from {}",
@@ -280,7 +276,7 @@ fn extract_products(
         .map(|path_str| CheckEntity::Source(manifest_dir.join(path_str), true))
         .collect::<HashSet<CheckEntity>>();
 
-    log::trace!("📜 explicit manifest products {:?}", &items);
+    log::trace!("📜 explicit manifest products {items:?}");
     Ok(items)
 }
 
@@ -383,7 +379,7 @@ fn handle_manifest<P: AsRef<Path>>(
                     )
                 })?;
                 let member_dirs = glob::glob(back_to_glob)?;
-                log::debug!("🪆 Handing manifest member: {}", &member_entry_glob);
+                log::debug!("🪆 Handing manifest member: {member_entry_glob}");
                 for member_dir in member_dirs {
                     let member_dir = member_dir?;
                     log::trace!(
@@ -434,7 +430,7 @@ pub(crate) fn extract(
         recurse = true;
     }
 
-    log::debug!("Running on inputs {:?} / recursive={}", &paths, recurse);
+    log::debug!("Running on inputs {paths:?} / recursive={recurse}");
 
     #[derive(Debug, Clone)]
     enum Extraction {
@@ -456,7 +452,7 @@ pub(crate) fn extract(
         path.canonicalize().ok()
     }));
 
-    log::debug!("Running on absolute dirs {:?} ", &flow);
+    log::debug!("Running on absolute dirs {flow:?}");
 
     // stage 2 - check for manifest, .rs , .md files and directories
     let mut files_to_check = Vec::with_capacity(64);
@@ -488,7 +484,7 @@ pub(crate) fn extract(
                     // if recursing is wanted
                     // and if it doesn't contain a manifest file
                     match fs::read_dir(path) {
-                        Err(err) => log::warn!("Listing directory contents {} failed", err),
+                        Err(err) => log::warn!("Listing directory contents {err} failed"),
                         Ok(entries) => {
                             for entry in entries.flatten() {
                                 let path = entry.path();
@@ -500,7 +496,7 @@ pub(crate) fn extract(
                     continue;
                 } else {
                     match fs::read_dir(path) {
-                        Err(err) => log::warn!("Listing directory contents {} failed", err),
+                        Err(err) => log::warn!("Listing directory contents {err} failed"),
                         Ok(entries) => {
                             for entry in entries.flatten() {
                                 let path = entry.path();

--- a/tests/signal_handler.rs
+++ b/tests/signal_handler.rs
@@ -45,10 +45,8 @@ fn signal_handler_works() -> Result<(), Box<dyn std::error::Error + 'static>> {
                 Ok(WaitStatus::Exited(_pid, _exit_code)) => {
                     return Ok(());
                 }
-                Ok(ws) => unreachable!("Unexpected wait status: {:?}", ws),
-                Err(errno) => {
-                    unreachable!("Did not expect an error: {:?}", errno);
-                }
+                Ok(ws) => unreachable!("Unexpected wait status: {ws:?}"),
+                Err(errno) => unreachable!("Did not expect an error: {errno:?}"),
             }
         }
     } else {


### PR DESCRIPTION
## What does this PR accomplish?

Most of the time you do not need to use an `&` when calling various format_args! methods - it automatically does that already, plus it causes about 5% perf degradation (compiler cannot optimize most of them due to some limitations discussed at rustlang).

I tried to cleanup a bit, plus a few tiny spacing fixes.  BTW, any reason not to remove `log::` prefix? I.e. add a `use log` at the top?

<!---
Delete all that do not apply:
-->

 * 🪣 Misc

## 📜 Checklist

 * [ ] Works on the `./demo` sub directory
 * [ ] Test coverage is excellent and passes
 * [ ] Documentation is thorough
