### PR TITLE
fix dead_code compile error

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -39,17 +39,6 @@ use std::fmt;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-// TODO figure out which ISO spec this actually is
-pub struct CommonLang(String);
-
-impl std::str::FromStr for CommonLang {
-    type Err = Error;
-    fn from_str(_s: &str) -> std::result::Result<Self, Self::Err> {
-        //
-        unimplemented!("Common Lang needs a ref spec")
-    }
-}
-
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Config {


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

<!---
Delete all that do not apply:
-->

 * 🩹 Bug Fix

<!---
Mention the linked issue here.
This will magically close the issue once the PR is merged.
-->

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

Rust 1.77 [merged `unused_tuple_struct_fields` into `dead_code`](https://github.com/rust-lang/rust/pull/118297/), which resulted in the build failing because `#![deny(dead_code)]` is set in `src/lib.rs`.

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particular impl details
are wanted, state them here too.
-->


## 📜 Checklist

 * [ ] Works on the `./demo` sub directory
 * [x] Test coverage is excellent and passes
 * [ ] Documentation is thorough
