### PR TITLE
feat/zspell: introduce featre `zet`, using `crate:zspell`

### DIFF
--- a/.config/lingo.dic
+++ b/.config/lingo.dic
@@ -51,6 +51,7 @@ recurse
 reflow
 Reflow/MS
 reflown
+reflow/MS
 roadmap/MS
 rustdoc/MS
 selectable
@@ -60,6 +61,7 @@ str
 stringly
 struct/MS
 TODO/MS
+TODO
 tokenization/MS
 tokenize/USXBMD
 tokenizer/MS

--- a/.config/spellcheck.toml
+++ b/.config/spellcheck.toml
@@ -8,6 +8,26 @@ extra_dictionaries = ["lingo.dic"]
 skip_os_lookups = true
 use_builtin = true
 
+[ZSpell]
+# lang and name of `.dic` file
+lang = "en_US"
+
+search_dirs = ["."]
+extra_dictionaries = ["lingo.dic"]
+
+skip_os_lookups = true
+use_builtin = true
+
+[Spellbook]
+# lang and name of `.dic` file
+lang = "en_US"
+
+search_dirs = ["."]
+extra_dictionaries = ["lingo.dic"]
+
+skip_os_lookups = true
+use_builtin = true
+
 
 [Hunspell.quirks]
 # transforms words that are provided by the tokenizer
@@ -25,7 +45,6 @@ transform_regex = [
 # of `alpha-beta`.
 allow_concatenation = true
 allow_dashed = true
-
 
 [Reflow]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,6 +2191,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spellbook"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fee930378e69527fbeb7e5f737e3ddaf32e675a04fc9375de676aa8de84693"
+dependencies = [
+ "ahash",
+ "hashbrown",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +46,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "always-assert"
@@ -296,6 +314,7 @@ dependencies = [
  "serde_plain",
  "sha2",
  "signal-hook",
+ "spellbook",
  "syn 2.0.66",
  "thiserror",
  "thousands",
@@ -304,6 +323,7 @@ dependencies = [
  "url",
  "uuid",
  "xz2",
+ "zspell",
 ]
 
 [[package]]
@@ -602,6 +622,15 @@ name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys 0.4.1",
 ]
@@ -994,6 +1023,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1166,6 +1199,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1259,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2162,6 +2210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringmetrics"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2248,15 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sys-locale"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e801cf239ecd6ccd71f03d270d67dd53d13e90aab208bf4b8fe4ad957ea949b0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "system-configuration"
@@ -2485,6 +2548,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +2609,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "walkdir"
@@ -2868,12 +2948,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
+name = "xxhash-rust"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2888,4 +2994,25 @@ dependencies = [
  "flate2",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "zspell"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd15eb5f5e7040be5fb1ad8ca0a8b4dd2ee7f6ee6f59d18a9b159bb12cb9b3a"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "dirs",
+ "hashbrown",
+ "indoc",
+ "itertools 0.13.0",
+ "lazy_static",
+ "regex",
+ "stringmetrics",
+ "sys-locale",
+ "unicode-segmentation",
+ "visibility",
+ "xxhash-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ hunspell-rs = { version = "0.4.0", optional = true }
 fd-lock = { version = "4", optional = true }
 encoding_rs = { version = "0.8.31", optional = true, features = [] }
 zspell = { version = "0.5.5", optional = true }
+spellbook = { version = "0.1", optional = true }
 
 # full grammar check, but also tokenization and disambiguation
 nlprule = { version = "=0.6.4", optional = true }
@@ -118,12 +119,11 @@ hunspell = [
   "nlprules",
   "dep:encoding_rs",
 ]
-zet = [
-  "dep:zspell",
-]
+zet = ["dep:zspell"]
+spellbook = ["dep:spellbook"]
 nlprules = ["dep:nlprule", "nlprule?/regex-fancy", "dep:nlprule-build"]
 
-all = ["hunspell", "nlprules"]
+all = ["hunspell", "zet", "spellbook", "nlprules"]
 
 [profile.dev]
 build-override = { opt-level = 2 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ url = { version = "2", features = ["serde"] }
 hunspell-rs = { version = "0.4.0", optional = true }
 fd-lock = { version = "4", optional = true }
 encoding_rs = { version = "0.8.31", optional = true, features = [] }
+zspell = { version = "0.5.5", optional = true }
 
 # full grammar check, but also tokenization and disambiguation
 nlprule = { version = "=0.6.4", optional = true }
@@ -107,7 +108,7 @@ serde_plain = "1"
 nix = "0.26.2"
 
 [features]
-default = ["hunspell", "nlprules"]
+default = ["all"]
 
 # hunspell uses the segmenter provided by nlprules
 hunspell = [
@@ -116,6 +117,9 @@ hunspell = [
   "dep:fd-lock",
   "nlprules",
   "dep:encoding_rs",
+]
+zet = [
+  "dep:zspell",
 ]
 nlprules = ["dep:nlprule", "nlprule?/regex-fancy", "dep:nlprule-build"]
 

--- a/doc-chunks/src/cluster.rs
+++ b/doc-chunks/src/cluster.rs
@@ -136,7 +136,7 @@ impl Clusters {
         };
         if doc_comments {
             let stream =
-                syn::parse_str::<proc_macro2::TokenStream>(source).map_err(|_e| Error::Any)?;
+                syn::parse_str::<proc_macro2::TokenStream>(source).map_err(Error::ParserFailure)?;
             chunk.parse_token_tree(source, stream)?;
         }
         if dev_comments {

--- a/doc-chunks/src/cluster.rs
+++ b/doc-chunks/src/cluster.rs
@@ -193,4 +193,17 @@ struct DefinitelyNotZ;
         assert_eq!(clusters.set.len(), 1);
         dbg!(&clusters.set[0]);
     }
+
+    #[test]
+    fn polite() {
+        static CONTENT: &str = r#####"
+// Hello Sir
+//
+// How are you doing today?
+struct VeryWellThanks;
+"#####;
+        let clusters = Clusters::load_from_str(CONTENT, true, true).unwrap();
+        assert_eq!(clusters.set.len(), 1);
+        dbg!(&clusters.set[0]);
+    }
 }

--- a/doc-chunks/src/errors.rs
+++ b/doc-chunks/src/errors.rs
@@ -11,6 +11,9 @@ pub enum Error {
     #[error("Really pretty much anything")]
     Any,
 
+    #[error("Failed to parse rust content: {0:?}")]
+    ParserFailure(#[source] syn::Error),
+
     #[error("Failed to parse toml file")]
     Toml(#[from] toml::de::Error),
 

--- a/src/checker/dictaffix.rs
+++ b/src/checker/dictaffix.rs
@@ -1,0 +1,157 @@
+use super::hunspell::cache_builtin;
+use super::Result;
+use crate::config::{Lang5, SearchDirs};
+use color_eyre::eyre::{bail, eyre, WrapErr};
+use fs_err as fs;
+use itertools::Itertools;
+use std::io;
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+
+pub(crate) struct DicAff {
+    pub(crate) dic: String,
+    pub(crate) aff: String,
+}
+
+impl DicAff {
+    pub(crate) fn load(
+        extra_dictionaries: &[std::path::PathBuf],
+        search_dirs: &SearchDirs,
+        lang: Lang5,
+        use_builtin: bool,
+        skip_os_lookups: bool,
+    ) -> Result<Self> {
+        let lang = lang.to_string();
+        let lang = lang.as_str();
+
+        // lookup paths are really just an attempt to provide a dictionary, so be more forgiving
+        // when encountering errors here
+        let (dic, aff): (PathBuf, PathBuf) = search_dirs.iter(!skip_os_lookups)
+        .into_iter()
+        .filter(|search_dir| {
+            let keep = search_dir.is_dir();
+            if !keep {
+                // search_dir also contains the default paths, so just silently ignore these
+                log::debug!(
+                    target: "affdic",
+                    "Dictionary search path is not a directory {}",
+                    search_dir.display()
+                );
+            } else {
+                log::debug!(
+                    target: "affdic",
+                    "Found dictionary search path {}",
+                    search_dir.display()
+                );
+            }
+            keep
+        })
+        .find_map(|search_dir| {
+            let dic = search_dir.join(lang).with_extension("dic");
+            if !dic.is_file() {
+                log::debug!(
+                    target: "affdic",
+                    "Dictionary path dervied from search dir is not a file {}",
+                    dic.display()
+                );
+                return None;
+            }
+            let aff = search_dir.join(lang).with_extension("aff");
+            if !aff.is_file() {
+                log::debug!(
+                    target: "affdic", 
+                    "Affixes path dervied from search dir is not a file {}",
+                    aff.display()
+                );
+                return None;
+            }
+            log::debug!("Using dic {} and aff {}", dic.display(), aff.display());
+            Some((dic, aff))
+        })
+        .ok_or_else(|| {
+            eyre!("Failed to find any {lang}.dic / {lang}.aff in any search dir or no search provided",
+                lang = lang)
+        })
+        .or_else(|e| {
+            if use_builtin {
+                Ok(cache_builtin()?)
+            } else {
+                Err(e)
+            }
+        })?;
+
+        let dic = fs_err::read_to_string(&dic)?;
+        let aff = fs_err::read_to_string(&aff)?;
+
+        // We need to combine multiple dictionaries into one
+        // since we want suffix support rather than plain word lists
+        let mut dic_acc = dic;
+
+        // suggestion must contain the word itself if it is valid extra dictionary
+        // be more strict about the extra dictionaries, they have to exist
+        log::info!(target: "dicaff", "Adding {} extra dictionaries", extra_dictionaries.len());
+
+        for extra_dic_path in extra_dictionaries {
+            log::debug!(target: "affdic", "Adding extra dictionary {}", extra_dic_path.display());
+            // after calling `sanitize_paths`
+            // the ought to be all absolutes
+            assert!(extra_dic_path.is_absolute());
+            let extra_dic = fs::read_to_string(extra_dic_path)?;
+            is_valid_hunspell_dic(&mut extra_dic.as_bytes())?;
+            log::trace!(target: "affdic", "Adding extra dict to main dict: {}", extra_dic.trim().lines().count() - 1);
+            dic_acc.push('\n');
+            // trim the initil number
+            dic_acc.push_str(
+                extra_dic
+                    .trim()
+                    .split_once("\n")
+                    .expect("It's a valid dictionary. qed")
+                    .1,
+            );
+        }
+
+        // sort them, just in case
+        let mut counter = 0;
+        let dic = dic_acc
+            .lines()
+            .inspect(|_line| counter += 1)
+            .into_iter()
+            .sorted()
+            .unique()
+            .join("\n");
+        let counter = counter.to_string();
+        let dic = counter + "\n" + dic.trim();
+
+        log::trace!(target: "affdic", "Total dictionary entries are: {}", dic.trim().lines().count() - 1);
+
+        Ok(Self { dic, aff })
+    }
+}
+
+/// Check if provided path has valid dictionary format.
+///
+/// This is a YOLO check.
+pub(crate) fn is_valid_hunspell_dic_path(path: impl AsRef<Path>) -> Result<()> {
+    let reader = io::BufReader::new(fs::File::open(path.as_ref())?);
+    is_valid_hunspell_dic(reader)
+}
+
+/// Check a reader for correct hunspell format.
+pub(crate) fn is_valid_hunspell_dic(reader: impl BufRead) -> Result<()> {
+    let mut iter = reader.lines().enumerate();
+    if let Some((_lineno, first)) = iter.next() {
+        let first = first?;
+        let _ = first.parse::<u64>().wrap_err_with(|| {
+            eyre!("First line of extra dictionary must a number, but is: >{first}<")
+        })?;
+    }
+    // Just check the first 10 lines, don't waste much time here
+    // the first two are the most important ones.
+    for (lineno, line) in iter.take(10) {
+        // All lines after must be format x.
+        if let Ok(num) = line?.parse::<i64>() {
+            bail!("Line {lineno} of extra dictionary must not be a number, but is: >{num}<",)
+        };
+    }
+    Ok(())
+}

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -76,17 +76,14 @@ impl Checkers {
                     log::debug!("Feature {} is disabled by compilation.", $feature);
                     None
                 } else {
-                    #[cfg(feature = $feature)]
-                    {
-                        let config = $config;
-                        let detector = <$checker>::detector();
-                        if config.is_enabled(detector) {
-                            log::debug!("Enabling {} checks.", detector);
-                            Some(<$checker>::new($checker_config.unwrap())?)
-                        } else {
-                            log::debug!("Checker {detector} is disabled by configuration.");
-                            None
-                        }
+                    let config = $config;
+                    let detector = <$checker>::detector();
+                    if config.is_enabled(detector) {
+                        log::debug!("Enabling {} checks.", detector);
+                        Some(<$checker>::new($checker_config.unwrap())?)
+                    } else {
+                        log::debug!("Checker {detector} is disabled by configuration.");
+                        None
                     }
                 }
             };

--- a/src/checker/spellbook.rs
+++ b/src/checker/spellbook.rs
@@ -1,0 +1,332 @@
+//! A dictionary check with affixes, backed by `libhunspell`
+//!
+//! Does not check grammar, but tokenizes the documentation chunk, and checks
+//! the individual tokens against the dictionary using the defined affixes. Can
+//! handle multiple dictionaries.
+
+use super::{apply_tokenizer, Checker, Detector, Suggestion};
+
+use crate::checker::dictaffix::DicAff;
+use crate::config::WrappedRegex;
+use crate::documentation::{CheckableChunk, ContentOrigin, PlainOverlay};
+use crate::util::sub_chars;
+use crate::Range;
+
+use fs_err as fs;
+
+use itertools::Itertools;
+use nlprule::Tokenizer;
+use std::io::{self, BufRead};
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use doc_chunks::Ignores;
+
+use crate::errors::*;
+
+use super::quirks::{
+    replacements_contain_dashed, replacements_contain_dashless, transform, Transformed,
+};
+
+use super::hunspell::{cache_builtin, consists_of_vulgar_fractions_or_emojis};
+
+#[derive(Clone)]
+pub struct SpellbookCheckerInner {
+    spellbook: ::spellbook::Dictionary,
+    transform_regex: Vec<WrappedRegex>,
+    allow_concatenated: bool,
+    allow_dashed: bool,
+    allow_emojis: bool,
+    check_footnote_references: bool,
+    ignorelist: String,
+}
+
+impl SpellbookCheckerInner {
+    fn new(config: &<SpellbookChecker as Checker>::Config) -> Result<Self> {
+        // TODO allow override
+        let (
+            transform_regex,
+            allow_concatenated,
+            allow_dashed,
+            allow_emojis,
+            check_footnote_references,
+        ) = {
+            let quirks = &config.quirks;
+            (
+                quirks.transform_regex().to_vec(),
+                quirks.allow_concatenated(),
+                quirks.allow_dashed(),
+                quirks.allow_emojis(),
+                quirks.check_footnote_references(),
+            )
+        };
+        // FIXME rename the config option
+        let ignorelist = config.tokenization_splitchars.clone();
+        // without these, a lot of those would be flagged as mistakes.
+        debug_assert!(ignorelist.contains(','));
+        debug_assert!(ignorelist.contains('.'));
+        debug_assert!(ignorelist.contains(';'));
+        debug_assert!(ignorelist.contains('!'));
+        debug_assert!(ignorelist.contains('?'));
+
+        let DicAff { dic, aff } = DicAff::load(
+            &config.extra_dictionaries[..],
+            &config.search_dirs,
+            config.lang(),
+            config.use_builtin,
+            config.skip_os_lookups,
+        )?;
+
+        let spellbook = ::spellbook::Dictionary::new(&aff, &dic)
+            .map_err(|e| eyre!("Failed to parse dictionary: {e}"))?;
+
+        log::debug!("Dictionary setup completed successfully.");
+        Ok(Self {
+            spellbook,
+            transform_regex,
+            allow_concatenated,
+            allow_dashed,
+            allow_emojis,
+            check_footnote_references,
+            ignorelist,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct SpellbookChecker(pub Arc<SpellbookCheckerInner>, pub Arc<Tokenizer>);
+
+impl std::ops::Deref for SpellbookChecker {
+    type Target = SpellbookCheckerInner;
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl SpellbookChecker {
+    pub fn new(config: &<SpellbookChecker as Checker>::Config) -> Result<Self> {
+        let tokenizer = super::tokenizer::<&PathBuf>(None)?;
+        let inner = SpellbookCheckerInner::new(config)?;
+        let hunspell = Arc::new(inner);
+        Ok(SpellbookChecker(hunspell, tokenizer))
+    }
+}
+
+impl Checker for SpellbookChecker {
+    type Config = crate::config::SpellbookConfig;
+
+    fn detector() -> Detector {
+        Detector::Spellbook
+    }
+
+    fn check<'a, 's>(
+        &self,
+        origin: &ContentOrigin,
+        chunks: &'a [CheckableChunk],
+    ) -> Result<Vec<Suggestion<'s>>>
+    where
+        'a: 's,
+    {
+        let mut acc = Vec::with_capacity(chunks.len());
+
+        for chunk in chunks {
+            let plain = chunk.erase_cmark(&Ignores {
+                footnote_references: !self.0.check_footnote_references,
+            });
+            log::trace!("{plain:?}");
+            let txt = plain.as_str();
+
+            'tokenization: for range in apply_tokenizer(&self.1, txt) {
+                let word = sub_chars(txt, range.clone());
+                if range.len() == 1
+                    && word
+                        .chars()
+                        .next()
+                        .filter(|c| self.ignorelist.contains(*c))
+                        .is_some()
+                {
+                    continue 'tokenization;
+                }
+                if self.transform_regex.is_empty() {
+                    obtain_suggestions(
+                        &plain,
+                        chunk,
+                        &self.spellbook,
+                        &origin,
+                        word,
+                        range,
+                        self.allow_concatenated,
+                        self.allow_dashed,
+                        self.allow_emojis,
+                        &mut acc,
+                    )
+                } else {
+                    match transform(&self.transform_regex[..], word.as_str(), range.clone()) {
+                        Transformed::Fragments(word_fragments) => {
+                            for (range, word_fragment) in word_fragments {
+                                obtain_suggestions(
+                                    &plain,
+                                    chunk,
+                                    &self.spellbook,
+                                    &origin,
+                                    word_fragment.to_owned(),
+                                    range,
+                                    self.allow_concatenated,
+                                    self.allow_dashed,
+                                    self.allow_emojis,
+                                    &mut acc,
+                                );
+                            }
+                        }
+                        Transformed::Atomic((range, word)) => {
+                            obtain_suggestions(
+                                &plain,
+                                chunk,
+                                &self.spellbook,
+                                &origin,
+                                word.to_owned(),
+                                range,
+                                self.allow_concatenated,
+                                self.allow_dashed,
+                                self.allow_emojis,
+                                &mut acc,
+                            );
+                        }
+                        Transformed::Whitelisted(_) => {}
+                    }
+                }
+            }
+        }
+        Ok(acc)
+    }
+}
+
+fn obtain_suggestions<'s>(
+    plain: &PlainOverlay,
+    chunk: &'s CheckableChunk,
+    dictionary: &::spellbook::Dictionary,
+    origin: &ContentOrigin,
+    word: String,
+    range: Range,
+    allow_concatenated: bool,
+    allow_dashed: bool,
+    allow_emojis: bool,
+    acc: &mut Vec<Suggestion<'s>>,
+) {
+    log::trace!("Checking {word} in {range:?}..");
+
+    match dictionary.check(&word) {
+        false => {
+            log::trace!(target: "spellbook", "No match for word (plain range: {range:?}): >{word}<");
+            // get rid of single character suggestions
+            let replacements = vec![];
+            // single char suggestions tend to be useless
+
+            log::debug!(target: "spellbook", "{word} --{{suggest}}--> {replacements:?}");
+
+            // strings made of vulgar fraction or emoji
+            if allow_emojis && consists_of_vulgar_fractions_or_emojis(&word) {
+                log::trace!(target: "quirks", "Found emoji or vulgar fraction character, treating {word} as ok");
+                return;
+            }
+
+            if allow_concatenated && replacements_contain_dashless(&word, replacements.as_slice()) {
+                log::trace!(target: "quirks", "Found dashless word in replacement suggestions, treating {word} as ok");
+                return;
+            }
+            if allow_dashed && replacements_contain_dashed(&word, replacements.as_slice()) {
+                log::trace!(target: "quirks", "Found dashed word in replacement suggestions, treating {word} as ok");
+                return;
+            }
+            for (range, span) in plain.find_spans(range.clone()) {
+                acc.push(Suggestion {
+                    detector: Detector::ZSpell,
+                    range,
+                    span,
+                    origin: origin.clone(),
+                    replacements: replacements.clone(),
+                    chunk,
+                    description: Some("Possible spelling mistake found.".to_owned()),
+                })
+            }
+        }
+        true => {
+            log::trace!(target: "spellbook", "Found a match for word (plain range: {range:?}): >{word}<",);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::checker::dictaffix::is_valid_hunspell_dic;
+
+    use super::*;
+
+    #[test]
+    fn hunspell_dic_format() {
+        const GOOD: &str = "2
+whitespazes
+catsndogs
+";
+        const BAD_1: &str = "foo
+12349
+bar
+";
+        const BAD_2: &str = "2
+12349
+bar
+";
+        const BAD_3: &str = "foo
+xxx
+bar
+";
+        assert!(is_valid_hunspell_dic(&mut GOOD.as_bytes()).is_ok());
+        assert!(is_valid_hunspell_dic(&mut BAD_1.as_bytes()).is_err());
+        assert!(is_valid_hunspell_dic(&mut BAD_2.as_bytes()).is_err());
+        assert!(is_valid_hunspell_dic(&mut BAD_3.as_bytes()).is_err());
+    }
+
+    macro_rules! parametrized_vulgar_fraction_or_emoji {
+        ($($name:ident: $value:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let (input, expected) = $value;
+                assert_eq!(expected, consists_of_vulgar_fractions_or_emojis(input));
+            }
+        )*
+        }
+    }
+
+    parametrized_vulgar_fraction_or_emoji! {
+        empty: ("", false),
+        emojis: ("🐍🤗🦀", true),
+        contains_emojis: ("🦀acean", false),
+        contains_only_unicode: ("⅔⅔⅔↉↉↉", true),
+        contains_emojis_and_unicodes: ("🐍🤗⅒🦀⅔¾", true),
+        no_emojis: ("no emoji string", false),
+        is_number: ("123", true),
+        is_latin_letter: ("a", false),
+        vulgar_fraction_one_quarter_and_emojis: ("¼🤗🦀", true),
+        emojis_and_vulgar_fraction_one_half: ("🤗🦀½", true),
+        emojis_and_vulgar_fraction_three_quarters: ("🤗🦀¾", true),
+        emojis_and_vulgar_fraction_one_seventh: ("🤗🦀⅐", true),
+        emojis_and_vulgar_fraction_one_ninth: ("🤗🦀⅑", true),
+        emojis_and_vulgar_fraction_one_tenth: ("🤗🦀⅒", true),
+        emojis_and_vulgar_fraction_one_third: ("🤗🦀⅓", true),
+        emojis_and_vulgar_fraction_two_thirds: ("🤗🦀⅔", true),
+        emojis_and_vulgar_fraction_one_fifth: ("🤗🦀⅕", true),
+        emojis_and_vulgar_fraction_two_fifth: ("🤗🦀⅖", true),
+        emojis_and_vulgar_fraction_three_fifths: ("🤗🦀⅗", true),
+        emojis_and_vulgar_fraction_four_fifths: ( "🐍⅘", true),
+        emojis_and_vulgar_fraction_one_sixth: ("🐍⅙", true),
+        emojis_and_vulgar_fraction_five_sixths: ("🐍⅚", true),
+        emojis_and_vulgar_fraction_one_eighth: ("🦀🐍⅛", true),
+        emojis_and_vulgar_fraction_three_eighths: ("🦀🐍⅜", true),
+        emojis_and_vulgar_fraction_five_eights: ("🦀🐍⅝", true),
+        emojis_and_vulgar_fraction_five_eighths: ("🦀🐍⅝", true),
+        emojis_and_vulgar_fraction_seven_eighths: ("🦀🐍⅞", true),
+        emojis_and_vulgar_fraction_zero_thirds: ("🦀🐍↉", true),
+    }
+}

--- a/src/checker/zspell.rs
+++ b/src/checker/zspell.rs
@@ -1,0 +1,331 @@
+//! A dictionary check with affixes, backed by `libhunspell`
+//!
+//! Does not check grammar, but tokenizes the documentation chunk, and checks
+//! the individual tokens against the dictionary using the defined affixes. Can
+//! handle multiple dictionaries.
+
+use super::{apply_tokenizer, Checker, Detector, Suggestion};
+
+use crate::checker::dictaffix::DicAff;
+use crate::config::WrappedRegex;
+use crate::documentation::{CheckableChunk, ContentOrigin, PlainOverlay};
+use crate::util::sub_chars;
+use crate::Range;
+
+use fs_err as fs;
+
+use itertools::Itertools;
+use nlprule::Tokenizer;
+use std::io::{self, BufRead};
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use doc_chunks::Ignores;
+
+use crate::errors::*;
+
+use super::quirks::{
+    replacements_contain_dashed, replacements_contain_dashless, transform, Transformed,
+};
+
+use super::hunspell::{cache_builtin, consists_of_vulgar_fractions_or_emojis};
+
+#[derive(Clone)]
+pub struct ZetCheckerInner {
+    zspell: zspell::Dictionary,
+    transform_regex: Vec<WrappedRegex>,
+    allow_concatenated: bool,
+    allow_dashed: bool,
+    allow_emojis: bool,
+    check_footnote_references: bool,
+    ignorelist: String,
+}
+
+impl ZetCheckerInner {
+    fn new(config: &<ZetChecker as Checker>::Config) -> Result<Self> {
+        // TODO allow override
+        let (
+            transform_regex,
+            allow_concatenated,
+            allow_dashed,
+            allow_emojis,
+            check_footnote_references,
+        ) = {
+            let quirks = &config.quirks;
+            (
+                quirks.transform_regex().to_vec(),
+                quirks.allow_concatenated(),
+                quirks.allow_dashed(),
+                quirks.allow_emojis(),
+                quirks.check_footnote_references(),
+            )
+        };
+        // FIXME rename the config option
+        let ignorelist = config.tokenization_splitchars.clone();
+        // without these, a lot of those would be flagged as mistakes.
+        debug_assert!(ignorelist.contains(','));
+        debug_assert!(ignorelist.contains('.'));
+        debug_assert!(ignorelist.contains(';'));
+        debug_assert!(ignorelist.contains('!'));
+        debug_assert!(ignorelist.contains('?'));
+
+        let DicAff { dic, aff } = DicAff::load(
+            &config.extra_dictionaries[..],
+            &config.search_dirs,
+            config.lang(),
+            config.use_builtin,
+            config.skip_os_lookups,
+        )?;
+
+        let zet = zspell::builder().config_str(&aff).dict_str(&dic).build()?;
+
+        log::debug!("Dictionary setup completed successfully.");
+        Ok(Self {
+            zspell: zet,
+            transform_regex,
+            allow_concatenated,
+            allow_dashed,
+            allow_emojis,
+            check_footnote_references,
+            ignorelist,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct ZetChecker(pub Arc<ZetCheckerInner>, pub Arc<Tokenizer>);
+
+impl std::ops::Deref for ZetChecker {
+    type Target = ZetCheckerInner;
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl ZetChecker {
+    pub fn new(config: &<ZetChecker as Checker>::Config) -> Result<Self> {
+        let tokenizer = super::tokenizer::<&PathBuf>(None)?;
+        let inner = ZetCheckerInner::new(config)?;
+        let hunspell = Arc::new(inner);
+        Ok(ZetChecker(hunspell, tokenizer))
+    }
+}
+
+impl Checker for ZetChecker {
+    type Config = crate::config::ZetConfig;
+
+    fn detector() -> Detector {
+        Detector::ZSpell
+    }
+
+    fn check<'a, 's>(
+        &self,
+        origin: &ContentOrigin,
+        chunks: &'a [CheckableChunk],
+    ) -> Result<Vec<Suggestion<'s>>>
+    where
+        'a: 's,
+    {
+        let mut acc = Vec::with_capacity(chunks.len());
+
+        for chunk in chunks {
+            let plain = chunk.erase_cmark(&Ignores {
+                footnote_references: !self.0.check_footnote_references,
+            });
+            log::trace!("{plain:?}");
+            let txt = plain.as_str();
+
+            'tokenization: for range in apply_tokenizer(&self.1, txt) {
+                let word = sub_chars(txt, range.clone());
+                if range.len() == 1
+                    && word
+                        .chars()
+                        .next()
+                        .filter(|c| self.ignorelist.contains(*c))
+                        .is_some()
+                {
+                    continue 'tokenization;
+                }
+                if self.transform_regex.is_empty() {
+                    obtain_suggestions(
+                        &plain,
+                        chunk,
+                        &self.zspell,
+                        &origin,
+                        word,
+                        range,
+                        self.allow_concatenated,
+                        self.allow_dashed,
+                        self.allow_emojis,
+                        &mut acc,
+                    )
+                } else {
+                    match transform(&self.transform_regex[..], word.as_str(), range.clone()) {
+                        Transformed::Fragments(word_fragments) => {
+                            for (range, word_fragment) in word_fragments {
+                                obtain_suggestions(
+                                    &plain,
+                                    chunk,
+                                    &self.zspell,
+                                    &origin,
+                                    word_fragment.to_owned(),
+                                    range,
+                                    self.allow_concatenated,
+                                    self.allow_dashed,
+                                    self.allow_emojis,
+                                    &mut acc,
+                                );
+                            }
+                        }
+                        Transformed::Atomic((range, word)) => {
+                            obtain_suggestions(
+                                &plain,
+                                chunk,
+                                &self.zspell,
+                                &origin,
+                                word.to_owned(),
+                                range,
+                                self.allow_concatenated,
+                                self.allow_dashed,
+                                self.allow_emojis,
+                                &mut acc,
+                            );
+                        }
+                        Transformed::Whitelisted(_) => {}
+                    }
+                }
+            }
+        }
+        Ok(acc)
+    }
+}
+
+fn obtain_suggestions<'s>(
+    plain: &PlainOverlay,
+    chunk: &'s CheckableChunk,
+    zspell: &zspell::Dictionary,
+    origin: &ContentOrigin,
+    word: String,
+    range: Range,
+    allow_concatenated: bool,
+    allow_dashed: bool,
+    allow_emojis: bool,
+    acc: &mut Vec<Suggestion<'s>>,
+) {
+    log::trace!("Checking {word} in {range:?}..");
+
+    match zspell.check_word(&word) {
+        false => {
+            log::trace!("No match for word (plain range: {range:?}): >{word}<");
+            // get rid of single character suggestions
+            let replacements = vec![];
+            // single char suggestions tend to be useless
+
+            log::debug!(target: "zspell", "{word} --{{suggest}}--> {replacements:?}");
+
+            // strings made of vulgar fraction or emoji
+            if allow_emojis && consists_of_vulgar_fractions_or_emojis(&word) {
+                log::trace!(target: "quirks", "Found emoji or vulgar fraction character, treating {word} as ok");
+                return;
+            }
+
+            if allow_concatenated && replacements_contain_dashless(&word, replacements.as_slice()) {
+                log::trace!(target: "quirks", "Found dashless word in replacement suggestions, treating {word} as ok");
+                return;
+            }
+            if allow_dashed && replacements_contain_dashed(&word, replacements.as_slice()) {
+                log::trace!(target: "quirks", "Found dashed word in replacement suggestions, treating {word} as ok");
+                return;
+            }
+            for (range, span) in plain.find_spans(range.clone()) {
+                acc.push(Suggestion {
+                    detector: Detector::ZSpell,
+                    range,
+                    span,
+                    origin: origin.clone(),
+                    replacements: replacements.clone(),
+                    chunk,
+                    description: Some("Possible spelling mistake found.".to_owned()),
+                })
+            }
+        }
+        true => {
+            log::trace!("Found a match for word (plain range: {range:?}): >{word}<",);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::checker::dictaffix::is_valid_hunspell_dic;
+
+    use super::*;
+
+    #[test]
+    fn hunspell_dic_format() {
+        const GOOD: &str = "2
+whitespazes
+catsndogs
+";
+        const BAD_1: &str = "foo
+12349
+bar
+";
+        const BAD_2: &str = "2
+12349
+bar
+";
+        const BAD_3: &str = "foo
+xxx
+bar
+";
+        assert!(is_valid_hunspell_dic(&mut GOOD.as_bytes()).is_ok());
+        assert!(is_valid_hunspell_dic(&mut BAD_1.as_bytes()).is_err());
+        assert!(is_valid_hunspell_dic(&mut BAD_2.as_bytes()).is_err());
+        assert!(is_valid_hunspell_dic(&mut BAD_3.as_bytes()).is_err());
+    }
+
+    macro_rules! parametrized_vulgar_fraction_or_emoji {
+        ($($name:ident: $value:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let (input, expected) = $value;
+                assert_eq!(expected, consists_of_vulgar_fractions_or_emojis(input));
+            }
+        )*
+        }
+    }
+
+    parametrized_vulgar_fraction_or_emoji! {
+        empty: ("", false),
+        emojis: ("🐍🤗🦀", true),
+        contains_emojis: ("🦀acean", false),
+        contains_only_unicode: ("⅔⅔⅔↉↉↉", true),
+        contains_emojis_and_unicodes: ("🐍🤗⅒🦀⅔¾", true),
+        no_emojis: ("no emoji string", false),
+        is_number: ("123", true),
+        is_latin_letter: ("a", false),
+        vulgar_fraction_one_quarter_and_emojis: ("¼🤗🦀", true),
+        emojis_and_vulgar_fraction_one_half: ("🤗🦀½", true),
+        emojis_and_vulgar_fraction_three_quarters: ("🤗🦀¾", true),
+        emojis_and_vulgar_fraction_one_seventh: ("🤗🦀⅐", true),
+        emojis_and_vulgar_fraction_one_ninth: ("🤗🦀⅑", true),
+        emojis_and_vulgar_fraction_one_tenth: ("🤗🦀⅒", true),
+        emojis_and_vulgar_fraction_one_third: ("🤗🦀⅓", true),
+        emojis_and_vulgar_fraction_two_thirds: ("🤗🦀⅔", true),
+        emojis_and_vulgar_fraction_one_fifth: ("🤗🦀⅕", true),
+        emojis_and_vulgar_fraction_two_fifth: ("🤗🦀⅖", true),
+        emojis_and_vulgar_fraction_three_fifths: ("🤗🦀⅗", true),
+        emojis_and_vulgar_fraction_four_fifths: ( "🐍⅘", true),
+        emojis_and_vulgar_fraction_one_sixth: ("🐍⅙", true),
+        emojis_and_vulgar_fraction_five_sixths: ("🐍⅚", true),
+        emojis_and_vulgar_fraction_one_eighth: ("🦀🐍⅛", true),
+        emojis_and_vulgar_fraction_three_eighths: ("🦀🐍⅜", true),
+        emojis_and_vulgar_fraction_five_eights: ("🦀🐍⅝", true),
+        emojis_and_vulgar_fraction_five_eighths: ("🦀🐍⅝", true),
+        emojis_and_vulgar_fraction_seven_eighths: ("🦀🐍⅞", true),
+        emojis_and_vulgar_fraction_zero_thirds: ("🦀🐍↉", true),
+    }
+}

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -28,6 +28,7 @@ pub struct ManifestMetadataSpellcheck {
 pub enum CheckerType {
     Hunspell,
     ZSpell,
+    Spellbook,
     NlpRules,
     Reflow,
 }
@@ -39,6 +40,7 @@ impl FromStr for CheckerType {
         Ok(match s.as_str() {
             "nlprules" => Self::NlpRules,
             "zet" | "zspell" => Self::ZSpell,
+            "spellbook" | "book" => Self::Spellbook,
             "hunspell" => Self::Hunspell,
             "reflow" => Self::Reflow,
             _other => return Err(UnknownCheckerTypeVariant(s)),
@@ -501,6 +503,13 @@ impl Args {
                 }
             } else {
                 config.zet = None;
+            }
+            if filter_set.contains(&CheckerType::Spellbook) {
+                if config.spellbook.is_none() {
+                    config.spellbook = Some(crate::config::SpellbookConfig::default());
+                }
+            } else {
+                config.spellbook = None;
             }
             if filter_set.contains(&CheckerType::NlpRules) {
                 if config.nlprules.is_none() {

--- a/src/config/hunspell.rs
+++ b/src/config/hunspell.rs
@@ -79,6 +79,8 @@ fn default_tokenization_splitchars() -> String {
     "\",;:.!?#(){}[]|/_-‒'`&@§¶…".to_owned()
 }
 
+pub type ZetConfig = HunspellConfig;
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct HunspellConfig {

--- a/src/config/hunspell.rs
+++ b/src/config/hunspell.rs
@@ -80,6 +80,7 @@ fn default_tokenization_splitchars() -> String {
 }
 
 pub type ZetConfig = HunspellConfig;
+pub type SpellbookConfig = HunspellConfig;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -57,6 +57,10 @@ pub struct Config {
     #[serde(default = "default_hunspell")]
     pub hunspell: Option<HunspellConfig>,
 
+    #[serde(alias = "ZSpell")]
+    #[serde(default = "default_zspell")]
+    pub zet: Option<ZetConfig>,
+
     #[serde(alias = "Nlp")]
     #[serde(alias = "NLP")]
     #[serde(alias = "nlp")]
@@ -79,6 +83,9 @@ impl Config {
     fn sanitize_paths(&mut self, base: &Path) -> Result<()> {
         if let Some(ref mut hunspell) = self.hunspell {
             hunspell.sanitize_paths(base)?;
+        }
+        if let Some(ref mut zspell) = self.zet {
+            zspell.sanitize_paths(base)?;
         }
         Ok(())
     }
@@ -210,6 +217,7 @@ impl Config {
     pub fn is_enabled(&self, detector: Detector) -> bool {
         match detector {
             Detector::Hunspell => self.hunspell.is_some(),
+            Detector::ZSpell => self.zet.is_some(),
             Detector::NlpRules => self.nlprules.is_some(),
             Detector::Reflow => self.reflow.is_some(),
             #[cfg(test)]
@@ -234,6 +242,9 @@ fn default_nlprules() -> Option<NlpRulesConfig> {
 fn default_hunspell() -> Option<HunspellConfig> {
     Some(HunspellConfig::default())
 }
+fn default_zspell() -> Option<ZetConfig> {
+    Some(ZetConfig::default())
+}
 
 impl Default for Config {
     fn default() -> Self {
@@ -241,6 +252,7 @@ impl Default for Config {
             dev_comments: false,
             skip_readme: false,
             hunspell: default_hunspell(),
+            zet: default_zspell(),
             nlprules: default_nlprules(),
             reflow: Some(ReflowConfig::default()),
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -80,8 +80,8 @@ pub struct Config {
 }
 
 impl Config {
-    const QUALIFIER: &'static str = "io";
-    const ORGANIZATION: &'static str = "spearow";
+    const QUALIFIER: &'static str = "rs";
+    const ORGANIZATION: &'static str = "fff";
     const APPLICATION: &'static str = "cargo_spellcheck";
 
     /// Sanitize all relative paths to absolute paths in relation to `base`.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -61,6 +61,11 @@ pub struct Config {
     #[serde(default = "default_zspell")]
     pub zet: Option<ZetConfig>,
 
+    #[serde(alias = "Spellbook")]
+    #[serde(alias = "book")]
+    #[serde(default = "default_spellbook")]
+    pub spellbook: Option<SpellbookConfig>,
+
     #[serde(alias = "Nlp")]
     #[serde(alias = "NLP")]
     #[serde(alias = "nlp")]
@@ -86,6 +91,9 @@ impl Config {
         }
         if let Some(ref mut zspell) = self.zet {
             zspell.sanitize_paths(base)?;
+        }
+        if let Some(ref mut spellbook) = self.spellbook {
+            spellbook.sanitize_paths(base)?;
         }
         Ok(())
     }
@@ -218,6 +226,7 @@ impl Config {
         match detector {
             Detector::Hunspell => self.hunspell.is_some(),
             Detector::ZSpell => self.zet.is_some(),
+            Detector::Spellbook => self.spellbook.is_some(),
             Detector::NlpRules => self.nlprules.is_some(),
             Detector::Reflow => self.reflow.is_some(),
             #[cfg(test)]
@@ -245,6 +254,9 @@ fn default_hunspell() -> Option<HunspellConfig> {
 fn default_zspell() -> Option<ZetConfig> {
     Some(ZetConfig::default())
 }
+fn default_spellbook() -> Option<SpellbookConfig> {
+    Some(SpellbookConfig::default())
+}
 
 impl Default for Config {
     fn default() -> Self {
@@ -253,6 +265,7 @@ impl Default for Config {
             skip_readme: false,
             hunspell: default_hunspell(),
             zet: default_zspell(),
+            spellbook: default_spellbook(),
             nlprules: default_nlprules(),
             reflow: Some(ReflowConfig::default()),
         }

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -27,6 +27,8 @@ pub enum Detector {
     Hunspell,
     /// ZSpell, compatible with hunspell dictionaries and affix files.
     ZSpell,
+    /// Spellbook
+    Spellbook,
     /// Language server rules based on NLP detector.
     NlpRules,
     /// Reflow according to a given max column.
@@ -42,6 +44,7 @@ impl Detector {
         match self {
             Self::Hunspell => "Hunspell",
             Self::ZSpell => "ZSpell",
+            Self::Spellbook => "Spellbook",
             Self::NlpRules => "NlpRules",
             Self::Reflow => "Reflow",
             #[cfg(test)]

--- a/src/suggestion.rs
+++ b/src/suggestion.rs
@@ -25,6 +25,8 @@ use crate::{Range, Span};
 pub enum Detector {
     /// Hunspell lib based detector.
     Hunspell,
+    /// ZSpell, compatible with hunspell dictionaries and affix files.
+    ZSpell,
     /// Language server rules based on NLP detector.
     NlpRules,
     /// Reflow according to a given max column.
@@ -39,6 +41,7 @@ impl Detector {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Hunspell => "Hunspell",
+            Self::ZSpell => "ZSpell",
             Self::NlpRules => "NlpRules",
             Self::Reflow => "Reflow",
             #[cfg(test)]


### PR DESCRIPTION
Currently doesn't support suggestions. Will obsolete `hunspell` eventually.

<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?


Add `zspell` based checking. Helpful since `hunspell` has some concurrency issues, see #332 
<!---
Delete all that do not apply:
-->

 * 🦚 Feature

## Changes proposed by this PR:

<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->


## Notes to reviewer:

* Currently we get a different set of detections.
* `suggestions` are currently not supported

## 📜 Checklist

 * [ ] Works on the `./demo` sub directory
 * [ ] Test coverage is excellent and passes
 * [ ] Documentation is thorough
