### PR TITLE
docs(readme): add Xcode requirement on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,27 @@ cargo spellcheck fix
 The `--locked` flag is the preferred way of installing to get the tested set of
 dependencies.
 
-on OS X, you need to ensure that `libclang.dylib` can be found by the linker
+### macOS
 
-which can be achieved by setting `DYLB_FALLBACK_LIBRARY_PATH`:
+On macOS, you need to install [Xcode](https://developer.apple.com/xcode/) and 
+to ensure that `libclang.dylib` can be found by the linker. Once you have installed
+XCode **and accepted its terms and conditions**, this can be achieved by setting 
+`DYLB_FALLBACK_LIBRARY_PATH`:
 
-```
+#### zsh
+
+```zsh
 export DYLD_FALLBACK_LIBRARY_PATH= \
     "$(xcode-select --print-path)/Toolchains/XcodeDefault.xctoolchain/usr/lib/"
 ```
+
+#### fish
+
+```fish
+set -gx DYLD_FALLBACK_LIBRARY_PATH "$(xcode-select --print-path)/Toolchains/XcodeDefault.xctoolchain/usr/lib/"
+```
+
+### Linux
 
 In Linux, the file is `libclang.so` which can be installed via:
 


### PR DESCRIPTION
## Description

I was having this issue https://github.com/drahnr/cargo-spellcheck/issues/320 and errors while installing with `cargo install cargo-spellcheck --locked` even with setting `DYLD_FALLBACK_LIBRARY_PATH` _correctly_.

## What does this PR accomplish?

It turns out Xcode needs to be installed and its terms accepted to successfully install cargo-spellcheck. Otherwise `DYLD_FALLBACK_LIBRARY_PATH` points to a Library folder that has nothing to do with `@rpath/libclang.dylib`. Yielding a failed cargo-spellcheck install.

 * 📙 Documentation

## Changes proposed by this PR:

Added instructions for macOS explicitly requiring Xcode installation and its terms acceptance.

## Notes to reviewer:

None.

## 📜 Checklist

 * [ ] Works on the `./demo` sub directory
 * [ ] Test coverage is excellent and passes
 * [x] Documentation is thorough
