### PR TITLE
feature/traverse: Add an option to rely purely on ignore files for traversing directories

### DIFF
--- a/src/checker/hunspell.rs
+++ b/src/checker/hunspell.rs
@@ -440,6 +440,7 @@ fn obtain_suggestions<'s>(
 #[cfg(test)]
 mod tests {
     use crate::checker::dictaffix::is_valid_hunspell_dic;
+    use std::io::BufRead;
 
     use super::*;
 

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -122,6 +122,10 @@ pub struct Common {
     /// argument paths, and also declared modules in rust files.
     pub recursive: bool,
 
+    // Use gitignore files to determine which file to check.
+    #[clap(short, long)]
+    pub use_gitignore_only: bool,
+
     // with fallback from config, so it has to be tri-state
     #[clap(long)]
     /// Execute the given subset of checkers.
@@ -196,6 +200,10 @@ pub enum Sub {
         #[clap(short, long)]
         /// Recurse down directories and module declaration derived paths.
         recursive: bool,
+   
+        // Use gitignore files to determine which files to list.
+        #[clap(short, long)]
+        use_gitignore_only: bool,
 
         #[clap(short, long)]
         /// Do not check the referenced key `readme=` or default `README.md`.
@@ -536,6 +544,7 @@ impl Args {
             Some(Sub::ListFiles {
                 ref paths,
                 recursive,
+                use_gitignore_only,
                 skip_readme,
             }) => UnifiedArgs::Operate {
                 action: self.action(),
@@ -543,6 +552,7 @@ impl Args {
                 dev_comments: false, // not relevant
                 skip_readme,
                 recursive,
+                use_gitignore_only,
                 paths: paths.clone(),
                 exit_code_override: 1,
             },
@@ -554,6 +564,7 @@ impl Args {
                     dev_comments: common.dev_comments || config.dev_comments,
                     skip_readme: common.skip_readme || config.skip_readme,
                     recursive: common.recursive,
+                    use_gitignore_only: common.use_gitignore_only,
                     paths: common.paths.clone(),
                     exit_code_override: common.code,
                 }
@@ -568,6 +579,7 @@ impl Args {
                 dev_comments: common.dev_comments || config.dev_comments,
                 skip_readme: common.skip_readme || config.skip_readme,
                 recursive: common.recursive,
+                use_gitignore_only: common.use_gitignore_only,
                 paths: common.paths.clone(),
                 exit_code_override: common.code,
             },
@@ -600,6 +612,7 @@ pub enum UnifiedArgs {
         dev_comments: bool,
         skip_readme: bool,
         recursive: bool,
+        use_gitignore_only: bool,
         paths: Vec<PathBuf>,
         exit_code_override: u8,
     },
@@ -819,6 +832,7 @@ mod tests {
                 dev_comments,
                 skip_readme,
                 recursive,
+                use_gitignore_only,
                 paths,
                 exit_code_override,
             } => {

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -122,9 +122,9 @@ pub struct Common {
     /// argument paths, and also declared modules in rust files.
     pub recursive: bool,
 
-    // Use gitignore files to determine which file to check.
+    /// Use gitignore files to determine which files to check.
     #[clap(short, long)]
-    pub use_gitignore_only: bool,
+    pub gitignore: bool,
 
     // with fallback from config, so it has to be tri-state
     #[clap(long)]
@@ -201,9 +201,9 @@ pub enum Sub {
         /// Recurse down directories and module declaration derived paths.
         recursive: bool,
    
-        // Use gitignore files to determine which files to list.
+        /// Use gitignore files to determine which files to list.
         #[clap(short, long)]
-        use_gitignore_only: bool,
+        gitignore: bool,
 
         #[clap(short, long)]
         /// Do not check the referenced key `readme=` or default `README.md`.
@@ -544,7 +544,7 @@ impl Args {
             Some(Sub::ListFiles {
                 ref paths,
                 recursive,
-                use_gitignore_only,
+                gitignore,
                 skip_readme,
             }) => UnifiedArgs::Operate {
                 action: self.action(),
@@ -552,7 +552,7 @@ impl Args {
                 dev_comments: false, // not relevant
                 skip_readme,
                 recursive,
-                use_gitignore_only,
+                gitignore,
                 paths: paths.clone(),
                 exit_code_override: 1,
             },
@@ -564,7 +564,7 @@ impl Args {
                     dev_comments: common.dev_comments || config.dev_comments,
                     skip_readme: common.skip_readme || config.skip_readme,
                     recursive: common.recursive,
-                    use_gitignore_only: common.use_gitignore_only,
+                    gitignore: common.gitignore,
                     paths: common.paths.clone(),
                     exit_code_override: common.code,
                 }
@@ -579,7 +579,7 @@ impl Args {
                 dev_comments: common.dev_comments || config.dev_comments,
                 skip_readme: common.skip_readme || config.skip_readme,
                 recursive: common.recursive,
-                use_gitignore_only: common.use_gitignore_only,
+                gitignore: common.gitignore,
                 paths: common.paths.clone(),
                 exit_code_override: common.code,
             },
@@ -612,7 +612,7 @@ pub enum UnifiedArgs {
         dev_comments: bool,
         skip_readme: bool,
         recursive: bool,
-        use_gitignore_only: bool,
+        gitignore: bool,
         paths: Vec<PathBuf>,
         exit_code_override: u8,
     },
@@ -832,7 +832,7 @@ mod tests {
                 dev_comments,
                 skip_readme,
                 recursive,
-                use_gitignore_only,
+                gitignore,
                 paths,
                 exit_code_override,
             } => {
@@ -841,6 +841,7 @@ mod tests {
                 assert_eq!(dev_comments, true);
                 assert_eq!(skip_readme, true);
                 assert_eq!(recursive, false);
+                assert_eq!(gitignore, false);
                 assert_eq!(paths, Vec::<PathBuf>::new());
             }
         );

--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -122,7 +122,9 @@ pub struct Common {
     /// argument paths, and also declared modules in rust files.
     pub recursive: bool,
 
-    /// Use gitignore files to determine which files to check.
+    /// Use gitignore files to determine which files to check. 
+    /// This flag also modifies the behaviour of the recursive flag 
+    /// to purely recurse down directories.
     #[clap(short, long)]
     pub gitignore: bool,
 
@@ -202,6 +204,8 @@ pub enum Sub {
         recursive: bool,
    
         /// Use gitignore files to determine which files to list.
+        /// This flag also modifies the behaviour of the recursive flag 
+        /// to purely recurse down directories.
         #[clap(short, long)]
         gitignore: bool,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ pub fn run(args: Args) -> Result<ExitCode> {
             action,
             paths,
             recursive,
-            use_gitignore_only,
+            gitignore,
             skip_readme,
             config_path,
             dev_comments,
@@ -153,7 +153,7 @@ pub fn run(args: Args) -> Result<ExitCode> {
             log::debug!("Executing: {action:?} with {config:?} from {config_path:?}");
 
             let documents =
-                traverse::extract(paths, recursive, use_gitignore_only, skip_readme, dev_comments, &config)?;
+                traverse::extract(paths, recursive, gitignore, skip_readme, dev_comments, &config)?;
 
             let rt = tokio::runtime::Runtime::new()?;
             let finish = rt.block_on(async move { action.run(documents, config).await })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@ pub fn run(args: Args) -> Result<ExitCode> {
             action,
             paths,
             recursive,
+            use_gitignore_only,
             skip_readme,
             config_path,
             dev_comments,
@@ -152,7 +153,7 @@ pub fn run(args: Args) -> Result<ExitCode> {
             log::debug!("Executing: {action:?} with {config:?} from {config_path:?}");
 
             let documents =
-                traverse::extract(paths, recursive, skip_readme, dev_comments, &config)?;
+                traverse::extract(paths, recursive, use_gitignore_only, skip_readme, dev_comments, &config)?;
 
             let rt = tokio::runtime::Runtime::new()?;
             let finish = rt.block_on(async move { action.run(documents, config).await })?;

--- a/src/traverse/iter.rs
+++ b/src/traverse/iter.rs
@@ -35,7 +35,7 @@ impl TraverseModulesIter {
         if meta.is_file() {
             self.queue.push_front((path, level));
         } else if meta.is_dir() {
-           ignore::WalkBuilder::new(path)
+            ignore::WalkBuilder::new(path)
                 .git_ignore(true)
                 .max_depth(1.into())
                 .same_file_system(true)

--- a/src/traverse/iter.rs
+++ b/src/traverse/iter.rs
@@ -76,7 +76,7 @@ impl TraverseModulesIter {
         Ok(me)
     }
 
-    pub fn with_depth_limit<P: AsRef<Path>>(path: P, max_depth: usize) -> Result<Self> {        
+    pub fn with_depth_limit<P: AsRef<Path>>(path: P, max_depth: usize) -> Result<Self> {
         let mut me = Self {
             max_depth,
             ..Default::default()

--- a/src/traverse/iter.rs
+++ b/src/traverse/iter.rs
@@ -29,57 +29,13 @@ impl TraverseModulesIter {
     where
         P: AsRef<Path>,
     {
-        log::debug!("Reached the start of add_initial_path()");
-
-        log::debug!("Backtrace: {}", std::backtrace::Backtrace::force_capture());
-
         let path = path.as_ref();
         let path = fs::canonicalize(path)?;
         let meta = fs::metadata(&path)?;
-
-        log::debug!("Got metadata for path");
-
         if meta.is_file() {
-            log::debug!("Path {} is a file", path.clone().to_string_lossy());
-
             self.queue.push_front((path, level));
         } else if meta.is_dir() {
-            log::debug!("Path {} is a directory", path.clone().to_string_lossy());
-
-            let mut walkbuilder = ignore::WalkBuilder::new(path);
-
-            let walkbuilder = walkbuilder
-            .git_ignore(true)
-            .max_depth(1.into())
-            .same_file_system(true)
-            .skip_stdout(true);
-
-            log::debug!("Configured walkbuilder");
-
-            let walk = walkbuilder.build();
-
-            log::debug!("Built walk");
-
-
-            walk.filter_map(|entry| {
-                entry
-                    .ok()
-                    .filter(|entry| entry.file_type().map(|ft| ft.is_file()).unwrap_or(false))
-                    .map(|x| x.path().to_owned())
-            })
-            .filter(|path: &PathBuf| {
-                path.to_str()
-                    .map(|x| x.to_owned())
-                    .filter(|path| path.ends_with(".rs"))
-                    .is_some()
-            })
-            .try_for_each::<_, Result<()>>(|path| {
-                log::trace!("🌱 using path {} as seed recursion dir", path.display());
-                self.queue.push_front((path, level));
-                Ok(())
-            })?;
-
-           /*ignore::WalkBuilder::new(path)
+           ignore::WalkBuilder::new(path)
                 .git_ignore(true)
                 .max_depth(1.into())
                 .same_file_system(true)
@@ -101,7 +57,7 @@ impl TraverseModulesIter {
                     log::trace!("🌱 using path {} as seed recursion dir", path.display());
                     self.queue.push_front((path, level));
                     Ok(())
-                })?;*/
+                })?;
         }
         Ok(())
     }
@@ -113,8 +69,6 @@ impl TraverseModulesIter {
         J: Iterator<Item = P>,
         I: IntoIterator<Item = P, IntoIter = J>,
     {
-        log::debug!("Reached the start of with_multi()");
-
         let mut me = Self::default();
         for path in entries.into_iter() {
             me.add_initial_path(path, 0)?;
@@ -122,9 +76,7 @@ impl TraverseModulesIter {
         Ok(me)
     }
 
-    pub fn with_depth_limit<P: AsRef<Path>>(path: P, max_depth: usize) -> Result<Self> {
-        log::debug!("Reached the start of with_depth_limit()");
-        
+    pub fn with_depth_limit<P: AsRef<Path>>(path: P, max_depth: usize) -> Result<Self> {        
         let mut me = Self {
             max_depth,
             ..Default::default()

--- a/src/traverse/mod.rs
+++ b/src/traverse/mod.rs
@@ -771,7 +771,7 @@ mod tests {
 
     macro_rules! extract_test {
 
-        ($name:ident, $gitignore:literal, [ $( $path:literal ),* $(,)?] + $recurse: expr  => [ $( $file:literal ),* $(,)?] ) => {
+        ($name:ident, $gitignore:literal, [ $( $path:literal ),* $(,)?] + $recurse: expr => [ $( $file:literal ),* $(,)?] ) => {
 
             #[test]
             fn $name() {

--- a/src/traverse/mod.rs
+++ b/src/traverse/mod.rs
@@ -781,15 +781,15 @@ mod tests {
 
     macro_rules! extract_test {
 
-        ($name:ident, [ $( $path:literal ),* $(,)?] + $recurse: expr => [ $( $file:literal ),* $(,)?] ) => {
+        ($name:ident, $use_gitignore_only:literal, [ $( $path:literal ),* $(,)?] + $recurse: literal  => [ $( $file:literal ),* $(,)?] ) => {
 
             #[test]
             fn $name() {
-                extract_test!([ $( $path ),* ] + $recurse => [ $( $file ),* ]);
+                extract_test!($use_gitignore_only, [ $( $path ),* ] + $recurse => [ $( $file ),* ]);
             }
         };
 
-        ([ $( $path:literal ),* $(,)?] + $recurse: expr => [ $( $file:literal ),* $(,)?] ) => {
+        ($use_gitignore_only:literal, [ $( $path:literal ),* $(,)?] + $recurse:literal => [ $( $file:literal ),* $(,)?] ) => {
             let _ = env_logger::builder()
                 .is_test(true)
                 .filter(None, log::LevelFilter::Trace)
@@ -802,6 +802,7 @@ mod tests {
                     )*
                 ],
                 $recurse,
+                $use_gitignore_only,
                 false,
                 true,
                 &Config::default(),
@@ -829,7 +830,7 @@ mod tests {
 
     #[test]
     fn traverse_manifest_1() {
-        extract_test!(["Cargo.toml"] + false => [
+        extract_test!(false, ["Cargo.toml"] + false => [
             // "Cargo.toml",
             "README.md",
             "src/lib.rs",
@@ -847,11 +848,11 @@ mod tests {
         ]);
     }
 
-    extract_test!(traverse_source_dir_1, ["src"] + false => [
+    extract_test!(traverse_source_dir_1, false, ["src"] + false => [
         "src/lib.rs",
         "src/main.rs"]);
 
-    extract_test!(traverse_source_dir_rec, ["src"] + true => [
+    extract_test!(traverse_source_dir_rec, false, ["src"] + true => [
         "src/lib.rs",
         "src/main.rs",
         "src/nested/again/mod.rs",
@@ -864,7 +865,7 @@ mod tests {
         "src/nested/mod.rs"
     ]);
 
-    extract_test!(traverse_manifest_dir_rec, ["."] + true => [
+    extract_test!(traverse_manifest_dir_rec, false, ["."] + true => [
         // "Cargo.toml",
         "README.md",
         "src/lib.rs",
@@ -881,7 +882,7 @@ mod tests {
         "member/procmacro/src/lib.rs",
     ]);
 
-    extract_test!(traverse_manifest_rec, ["Cargo.toml"] + true => [
+    extract_test!(traverse_manifest_rec, false, ["Cargo.toml"] + true => [
         // "Cargo.toml",
         "README.md",
         "src/lib.rs",
@@ -898,11 +899,11 @@ mod tests {
         "member/procmacro/src/lib.rs",
     ]);
 
-    extract_test!(traverse_nested_mod_rs_1, ["src/nested/mod.rs"] + false => [
+    extract_test!(traverse_nested_mod_rs_1, false, ["src/nested/mod.rs"] + false => [
         "src/nested/mod.rs"
     ]);
 
-    extract_test!(traverse_nested_mod_rs_rec, ["src/nested/mod.rs"] + true => [
+    extract_test!(traverse_nested_mod_rs_rec, false, ["src/nested/mod.rs"] + true => [
         "src/nested/again/mod.rs",
         "src/nested/again/code.rs",
         "src/nested/fragments/enumerate.rs",
@@ -913,7 +914,7 @@ mod tests {
         "src/nested/mod.rs"
     ]);
 
-    extract_test!(traverse_dir_wo_manifest, ["member"] + true => [
+    extract_test!(traverse_dir_wo_manifest, false, ["member"] + true => [
         "member/true/lib.rs",
         "member/true/README.md",
         // "member/true/Cargo.toml",

--- a/src/traverse/mod.rs
+++ b/src/traverse/mod.rs
@@ -515,7 +515,7 @@ pub(crate) fn extract(
         files_to_check.push(x);
     }
 
-    log::debug!("Found a total of {} files to check ", files_to_check.len());
+    log::debug!("(1) Found a total of {} files to check ", files_to_check.len());
 
     // stage 3 - resolve the manifest products and workspaces, warn about missing
     let files_to_check = files_to_check
@@ -535,6 +535,8 @@ pub(crate) fn extract(
             }
             Ok(acc)
         })?;
+
+    log::debug!("(2) Found a total of {} files to check ", files_to_check.len());
 
     // stage 4 - expand from the passed source files, if recursive, recurse down the module train
     let docs = files_to_check.into_iter().try_fold(
@@ -562,6 +564,8 @@ pub(crate) fn extract(
                                 },
                             ));
                         docs.extend(iter);
+
+                        log::debug!("Intermediate number of files: {}", docs.len());
                     }
                 }
                 CheckEntity::Markdown(path) => {
@@ -582,6 +586,12 @@ pub(crate) fn extract(
             Result::Ok(docs)
         },
     )?;
+
+    log::debug!("Number of files: {}", docs.len());
+
+    for (doc_number, (doc_origin, _doc_chunks)) in docs.clone().into_iter().enumerate() {
+        log::debug!("File no: {}, file path: {}", doc_number, doc_origin.as_path().to_string_lossy());
+    }
 
     Result::Ok(docs)
 }

--- a/src/traverse/mod.rs
+++ b/src/traverse/mod.rs
@@ -427,7 +427,6 @@ pub(crate) fn extract(
         recurse = true;
     }
 
-
     log::debug!("Running on inputs {paths:?} / recursive={recurse}");
 
     #[derive(Debug, Clone)]
@@ -578,6 +577,8 @@ pub(crate) fn extract(
             files_to_check.push(x);
         }
     }
+    
+    log::debug!("Found a total of {} files to check ", files_to_check.len());
 
     // stage 3 - resolve the manifest products and workspaces, warn about missing
     let files_to_check = files_to_check
@@ -626,8 +627,6 @@ pub(crate) fn extract(
                                 },
                             ));
                         docs.extend(iter);
-
-                        log::debug!("Intermediate number of files: {}", docs.len());
                     }
                 }
                 CheckEntity::Markdown(path) => {
@@ -641,7 +640,7 @@ pub(crate) fn extract(
                 CheckEntity::ManifestDescription(path, content) => {
                     if content.is_empty() {
                         bail!("Cargo.toml manifest description field is empty")
-                    } 
+                    }
                     docs.add_cargo_manifest_description(path, content.as_str())?;
                 }
             }
@@ -772,7 +771,7 @@ mod tests {
 
     macro_rules! extract_test {
 
-        ($name:ident, $gitignore:literal, [ $( $path:literal ),* $(,)?] + $recurse: literal  => [ $( $file:literal ),* $(,)?] ) => {
+        ($name:ident, $gitignore:literal, [ $( $path:literal ),* $(,)?] + $recurse: expr  => [ $( $file:literal ),* $(,)?] ) => {
 
             #[test]
             fn $name() {
@@ -780,7 +779,7 @@ mod tests {
             }
         };
 
-        ($gitignore:literal, [ $( $path:literal ),* $(,)?] + $recurse:literal => [ $( $file:literal ),* $(,)?] ) => {
+        ($gitignore:literal, [ $( $path:literal ),* $(,)?] + $recurse: expr => [ $( $file:literal ),* $(,)?] ) => {
             let _ = env_logger::builder()
                 .is_test(true)
                 .filter(None, log::LevelFilter::Trace)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cargo-spellcheck!
-->

## What does this PR accomplish?

 * 🦚 Feature


## Changes proposed by this PR:

This pr adds an option flag to change the behaviour of the traversal module to collect all relevant files except those which match an entry in a .gitignore file. Our usecase for this is to be able to ignore certain temporary Markdown files which are pulled in when building our documentation.

## Notes to reviewer:

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particular impl details
are wanted, state them here too.
-->


## 📜 Checklist

 * [ ] Works on the `./demo` sub directory
 * [ ] Test coverage is excellent and passes
 * [ ] Documentation is thorough
