### PR TITLE
chore: when using ubuntu, use hardened intermediate container

### DIFF
--- a/.github/actions/install-clang/action.yml
+++ b/.github/actions/install-clang/action.yml
@@ -8,6 +8,11 @@ runs:
       shell: bash
       run: apk add clang oniguruma-dev
 
-    - name: Ensure onig_sys uses libonig
+    - name: Ensure rust-onig builds, and does so statically
       shell: bash
-      run: echo "RUSTONIG_SYSTEM_LIBONIG=1" >> "${GITHUB_ENV}"
+      run: |
+        # rust-onig does not build against anything newer.
+        echo "CFLAGS=-std=gnu17" >> "${GITHUB_ENV}"
+
+        # ensure we statically link against libonig
+        echo "RUSTONIG_STATIC_LIBONIG=1" >> "${GITHUB_ENV}"

--- a/.github/actions/install-clang/action.yml
+++ b/.github/actions/install-clang/action.yml
@@ -12,7 +12,7 @@ runs:
       shell: bash
       run: |
         # rust-onig does not build against anything newer.
-        echo "CFLAGS=-std=gnu17" >> "${GITHUB_ENV}"
+        # echo "CFLAGS=-std=gnu17" >> "${GITHUB_ENV}"
 
         # ensure we statically link against libonig
         echo "RUSTONIG_STATIC_LIBONIG=1" >> "${GITHUB_ENV}"

--- a/.github/actions/install-clang/action.yml
+++ b/.github/actions/install-clang/action.yml
@@ -1,9 +1,13 @@
-name: "Install libclang-dev"
-description: "Reusable action to set up libclang-dev"
+name: Install build prerequisites
+description: Reusable action to set up build prerequisites
 
 runs:
   using: "composite"
   steps:
-    - name: Install libclang-dev
+    - name: Install build prerequisites
       shell: bash
-      run: sudo apt-get install --no-install-recommends --yes libclang-dev
+      run: apk add clang oniguruma-dev
+
+    - name: Ensure onig_sys uses libonig
+      shell: bash
+      run: echo "RUSTONIG_SYSTEM_LIBONIG=1" >> "${GITHUB_ENV}"

--- a/.github/actions/install-clang/action.yml
+++ b/.github/actions/install-clang/action.yml
@@ -8,11 +8,8 @@ runs:
       shell: bash
       run: apk add clang oniguruma-dev
 
-    - name: Ensure rust-onig builds, and does so statically
+    - name: Force rust-onig static linking
       shell: bash
       run: |
-        # rust-onig does not build against anything newer.
-        # echo "CFLAGS=-std=gnu17" >> "${GITHUB_ENV}"
-
         # ensure we statically link against libonig
         echo "RUSTONIG_STATIC_LIBONIG=1" >> "${GITHUB_ENV}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,6 @@ jobs:
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Set up cache
-        uses: Swatinem/rust-cache@v2
-
       - uses: ./.github/actions/install-clang
 
       - name: Build
@@ -90,9 +87,6 @@ jobs:
 
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Set up cache
-        uses: Swatinem/rust-cache@v2
 
       - uses: ./.github/actions/install-clang
 
@@ -131,9 +125,6 @@ jobs:
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Set up cache
-        uses: Swatinem/rust-cache@v2
-
       - uses: ./.github/actions/install-clang
 
       - name: Install english dictionary
@@ -156,9 +147,6 @@ jobs:
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Set up cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Build
         shell: pwsh
         run: cargo build --target aarch64-pc-windows-msvc
@@ -174,9 +162,6 @@ jobs:
 
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Set up cache
-        uses: Swatinem/rust-cache@v2
 
       - name: Build
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
   fmt:
     name: Format check
     runs-on: ubuntu-latest
+    container:
+      image: cgr.dev/chainguard/rust:latest-dev
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,6 +39,9 @@ jobs:
   build:
     name: Build (Linux x86_64, GNU)
     runs-on: ubuntu-latest
+    container:
+      image: cgr.dev/chainguard/rust:latest-dev
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,6 +69,9 @@ jobs:
   build-aarch64-linux:
     name: Build (Linux aarch64, GNU)
     runs-on: ubuntu-24.04-arm
+    container:
+      image: cgr.dev/chainguard/rust:latest-dev
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,6 +99,9 @@ jobs:
   test:
     name: Unit tests
     runs-on: ubuntu-latest
+    container:
+      image: cgr.dev/chainguard/rust:latest-dev
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -103,6 +115,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - uses: ./.github/actions/install-clang
+
+      - name: Install english dictionary
+        shell: bash
+        run: apk add hunspell-dictionary-en
 
       - name: Run tests
         shell: bash
@@ -150,11 +166,18 @@ jobs:
     name: Validate spellcheck
     needs: build
     runs-on: ubuntu-latest
+    container:
+      image: cgr.dev/chainguard/rust:latest-dev
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           show-progress: false
+
+      - name: Install oniguruma
+        shell: bash
+        run: apk add oniguruma-dev
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -185,11 +208,18 @@ jobs:
     name: Validate reflow
     needs: build
     runs-on: ubuntu-latest
+    container:
+      image: cgr.dev/chainguard/rust:latest-dev
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           show-progress: false
+
+      - name: Install oniguruma
+        shell: bash
+        run: apk add oniguruma-dev
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,16 @@ jobs:
         shell: bash
         run: cargo build --release
 
+      - name: Verify no libonig dependency
+        shell: bash
+        run: |
+          dynamic=$(readelf --dynamic target/release/cargo-spellcheck)
+          echo "${dynamic}"
+          if echo "${dynamic}" | grep -q libonig; then
+            echo "ERROR: binary has a runtime dependency on libonig"
+            exit 1
+          fi
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -89,6 +99,16 @@ jobs:
       - name: Build
         shell: bash
         run: cargo build --release
+
+      - name: Verify no libonig dependency
+        shell: bash
+        run: |
+          dynamic=$(readelf --dynamic target/release/cargo-spellcheck)
+          echo "${dynamic}"
+          if echo "${dynamic}" | grep -q libonig; then
+            echo "ERROR: binary has a runtime dependency on libonig"
+            exit 1
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,6 @@ jobs:
         with:
           targets: x86_64-unknown-linux-gnu
 
-      - name: Set up cache
-        uses: Swatinem/rust-cache@v2
-
       - uses: ./.github/actions/install-clang
 
       - name: Build
@@ -63,9 +60,6 @@ jobs:
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Set up cache
-        uses: Swatinem/rust-cache@v2
-
       - uses: ./.github/actions/install-clang
 
       - name: Build
@@ -96,9 +90,6 @@ jobs:
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Set up cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Build
         shell: pwsh
         run: cargo build --release --target x86_64-pc-windows-msvc
@@ -126,9 +117,6 @@ jobs:
 
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Set up cache
-        uses: Swatinem/rust-cache@v2
 
       - name: Build
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
   build-linux-x86_64:
     name: Build Linux binary (x86_64, GNU)
     runs-on: ubuntu-latest
+    container:
+      image: cgr.dev/chainguard/rust:latest-dev
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,6 +51,9 @@ jobs:
   build-linux-aarch64:
     name: Build Linux binary (aarch64, GNU)
     runs-on: ubuntu-24.04-arm
+    container:
+      image: cgr.dev/chainguard/rust:latest-dev
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -149,6 +155,9 @@ jobs:
       - build-windows-aarch64
 
     runs-on: ubuntu-latest
+    container:
+      image: cgr.dev/chainguard/rust:latest-dev
+      options: --user root
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows-x86_64-msvc-binary
+          name: windows-x86_64-binary
           path: cargo-spellcheck-*-x86_64-pc-windows-msvc.exe
 
   build-windows-aarch64:
@@ -167,11 +167,6 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: windows-x86_64-msvc-binary
-
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
           name: windows-aarch64-binary
 
       - name: Create release
@@ -181,6 +176,5 @@ jobs:
           files: |
             cargo-spellcheck-*-x86_64-unknown-linux-gnu
             cargo-spellcheck-*-aarch64-unknown-linux-gnu
-            cargo-spellcheck-*-x86_64-pc-windows-gnu.exe
             cargo-spellcheck-*-x86_64-pc-windows-msvc.exe
             cargo-spellcheck-*-aarch64-pc-windows-msvc.exe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",


### PR DESCRIPTION
## What does this PR accomplish?

 * 🪣 Misc

## Changes proposed by this PR:

Use a hardened image when testing & building.


## Notes to reviewer:

Running as is Chainguard's sanctioned way to install packages: https://edu.chainguard.dev/chainguard/chainguard-images/about/differences-development-production/#:~:text=Chainguard%20Containers%20use,packages%20with%20apk.


## 📜 Checklist

 * [ ] Works on the `./demo` sub directory
 * [ ] Test coverage is excellent and passes
 * [ ] Documentation is thorough
